### PR TITLE
fix: prevent endless loading screen after clearing cookies/local storage

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Center, Spinner } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import NavBar from '../../components/NavBar';
@@ -19,8 +19,44 @@ export default function DashboardPage() {
     }
   }, [address, router, isInitialized]);
   
+  // Redirect to home if not connected regardless of initialization state
+  useEffect(() => {
+    // If no address, redirect to login regardless of isInitialized state
+    // This ensures we don't get stuck in a loading screen
+    if (!address) {
+      console.log("No wallet address detected, redirecting to login");
+      router.push('/');
+    }
+  }, [address, router]);
+  
   // Show loading spinner while wallet state is initializing
   if (!isInitialized) {
+    return (
+      <Center height="100vh" className="bg-gray-900">
+        <Spinner size="xl" color="purple.500" thickness="4px" />
+      </Center>
+    );
+  }
+  
+  // Show loading spinner while wallet state is initializing, but with a timeout
+  // to prevent infinite loading
+  const [showLoading, setShowLoading] = useState(true);
+  
+  useEffect(() => {
+    // Set a timeout to stop showing the loading spinner after 3 seconds
+    const timer = setTimeout(() => {
+      setShowLoading(false);
+      // If still not initialized, redirect to login
+      if (!isInitialized && !address) {
+        console.log("Wallet initialization timed out, redirecting to login");
+        router.push('/');
+      }
+    }, 3000);
+    
+    return () => clearTimeout(timer);
+  }, [isInitialized, address, router]);
+  
+  if (!isInitialized && showLoading) {
     return (
       <Center height="100vh" className="bg-gray-900">
         <Spinner size="xl" color="purple.500" thickness="4px" />

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Center, Spinner } from '@chakra-ui/react';
 import NavBar from '../../components/NavBar';
 import Game from '../../components/gameboard/game';
@@ -18,6 +18,16 @@ export default function GamePage() {
       router.push('/');
     }
   }, [address, router, isInitialized]);
+  
+  // Redirect to home if not connected, but only after wallet state is initialized
+  useEffect(() => {
+    // If no address, redirect to login regardless of isInitialized state
+    // This ensures we don't get stuck in a loading screen
+    if (!address) {
+      console.log("No wallet address detected, redirecting to login");
+      router.push('/');
+    }
+  }, [address, router]);
   
   // Check if we're coming from character creation
   React.useEffect(() => {
@@ -44,9 +54,30 @@ export default function GamePage() {
     );
   }
   
-  // Early return if no wallet to prevent UI flicker
-  if (!address) {
-    return null; // Will redirect
+  // Show loading spinner while wallet state is initializing, but with a timeout
+  // to prevent infinite loading
+  const [showLoading, setShowLoading] = useState(true);
+  
+  useEffect(() => {
+    // Set a timeout to stop showing the loading spinner after 3 seconds
+    const timer = setTimeout(() => {
+      setShowLoading(false);
+      // If still not initialized, redirect to login
+      if (!isInitialized && !address) {
+        console.log("Wallet initialization timed out, redirecting to login");
+        router.push('/');
+      }
+    }, 3000);
+    
+    return () => clearTimeout(timer);
+  }, [isInitialized, address, router]);
+  
+  if (!isInitialized && showLoading) {
+    return (
+      <Center height="100vh" className="bg-gray-900">
+        <Spinner size="xl" color="purple.500" thickness="4px" />
+      </Center>
+    );
   }
   
   return (

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -73,8 +73,9 @@ const Login: React.FC = () => {
     // Redirect will happen in the useEffect above
   };
 
-  // Show loading when wallet provider is initializing or we're checking character
-  if (!isInitialized || checkingCharacter) {
+  // Show loading spinner only for active operations, not for wallet initialization
+  // This prevents infinite loading screens when wallet provider fails to initialize
+  if (checkingCharacter || !ready) {
     return (
       <Center height="100vh" bg="gray.900">
         <Spinner size="xl" color="purple.500" thickness="4px" />


### PR DESCRIPTION
- WalletProvider: Ensure isInitialized becomes true even when authentication fails
- Login: Show login UI without waiting for wallet initialization to complete
- Game/Dashboard pages: Add immediate redirects when no address is found and failsafe timeout
- Improve error handling across components to prevent loading states from becoming stuck

This resolves the issue where users get stuck on loading screens after clearing cookies or local storage.