### PR TITLE
fix combat log mapping

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useGame } from '../hooks/game/useGame';
+import { useBattleNads } from '../hooks/game/useBattleNads';
 import Login from './auth/Login';
 import LoadingScreen from './game/screens/LoadingScreen';
 import ErrorScreen from './game/screens/ErrorScreen';
@@ -14,6 +15,14 @@ const AppInitializer: React.FC = () => {
   const game = useGame();
   const router = useRouter();
   const zeroCharacterId = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  // Also get equipment names data from useBattleNads
+  const { 
+    rawEquipableWeaponIDs,
+    rawEquipableWeaponNames,
+    rawEquipableArmorIDs,
+    rawEquipableArmorNames 
+  } = useBattleNads(game.owner);
 
   const renderWithNav = (content: React.ReactNode, label?: string) => {
     return (
@@ -124,6 +133,11 @@ const AppInitializer: React.FC = () => {
            isSendingChat={game.isSendingChat}
            isInCombat={game.isInCombat}
            isCacheLoading={game.isCacheLoading}
+           // Add equipment names data
+           equipableWeaponIDs={rawEquipableWeaponIDs}
+           equipableWeaponNames={rawEquipableWeaponNames}
+           equipableArmorIDs={rawEquipableArmorIDs}
+           equipableArmorNames={rawEquipableArmorNames}
          />,
          "Game Container"
       );

--- a/src/components/game/GameContainer.tsx
+++ b/src/components/game/GameContainer.tsx
@@ -35,6 +35,11 @@ interface GameContainerProps {
   isInCombat: boolean;
   addOptimisticChatMessage: (message: string) => void;
   isCacheLoading: boolean;
+  // Add equipment names for lookup
+  equipableWeaponIDs?: number[];
+  equipableWeaponNames?: string[];
+  equipableArmorIDs?: number[];
+  equipableArmorNames?: string[];
 }
 
 const GameContainer: React.FC<GameContainerProps> = (props) => {
@@ -50,7 +55,11 @@ const GameContainer: React.FC<GameContainerProps> = (props) => {
     isSendingChat,
     isInCombat,
     addOptimisticChatMessage,
-    isCacheLoading
+    isCacheLoading,
+    equipableWeaponIDs,
+    equipableWeaponNames,
+    equipableArmorIDs,
+    equipableArmorNames
   } = props;
 
   const isSpawned = !(position.x === 0 && position.y === 0 && position.z === 0);
@@ -168,6 +177,10 @@ const GameContainer: React.FC<GameContainerProps> = (props) => {
           addOptimisticChatMessage={addOptimisticChatMessage}
           isInCombat={isInCombat}
           isCacheLoading={isCacheLoading}
+          equipableWeaponIDs={equipableWeaponIDs}
+          equipableWeaponNames={equipableWeaponNames}
+          equipableArmorIDs={equipableArmorIDs}
+          equipableArmorNames={equipableArmorNames}
         />
       </Flex>
     </Box>

--- a/src/components/game/feed/EventFeed.tsx
+++ b/src/components/game/feed/EventFeed.tsx
@@ -9,13 +9,22 @@ interface EventFeedProps {
   eventLogs: domain.EventMessage[];
   combatants: domain.CharacterLite[];
   isCacheLoading: boolean;
+  // Add equipment names for lookup
+  equipableWeaponIDs?: number[];
+  equipableWeaponNames?: string[];
+  equipableArmorIDs?: number[];
+  equipableArmorNames?: string[];
 }
 
 const EventFeed: React.FC<EventFeedProps> = ({ 
   playerIndex,
   eventLogs,
   combatants, 
-  isCacheLoading 
+  isCacheLoading,
+  equipableWeaponIDs,
+  equipableWeaponNames,
+  equipableArmorIDs,
+  equipableArmorNames
 }) => {
   
   const parentRef = useRef<HTMLDivElement>(null);
@@ -49,6 +58,47 @@ const EventFeed: React.FC<EventFeedProps> = ({
   });
   
   const combatantIds = useMemo(() => new Set(combatants.map(c => c.id)), [combatants]);
+
+  // Create equipment name lookup functions
+  const getWeaponName = useMemo(() => {
+    return (weaponId: number): string => {
+      if (!equipableWeaponIDs || !equipableWeaponNames) {
+        return `Weapon ${weaponId}`;
+      }
+      
+      // Convert weaponId to number if it's not already
+      const numericWeaponId = Number(weaponId);
+      
+      // Find the index of this weapon ID in the array
+      const index = equipableWeaponIDs.findIndex(id => Number(id) === numericWeaponId);
+      
+      if (index >= 0 && equipableWeaponNames[index]) {
+        return equipableWeaponNames[index];
+      }
+      
+      return `Weapon ${weaponId}`;
+    };
+  }, [equipableWeaponIDs, equipableWeaponNames]);
+
+  const getArmorName = useMemo(() => {
+    return (armorId: number): string => {
+      if (!equipableArmorIDs || !equipableArmorNames) {
+        return `Armor ${armorId}`;
+      }
+      
+      // Convert armorId to number if it's not already
+      const numericArmorId = Number(armorId);
+      
+      // Find the index of this armor ID in the array
+      const index = equipableArmorIDs.findIndex(id => Number(id) === numericArmorId);
+      
+      if (index >= 0 && equipableArmorNames[index]) {
+        return equipableArmorNames[index];
+      }
+      
+      return `Armor ${armorId}`;
+    };
+  }, [equipableArmorIDs, equipableArmorNames]);
 
   return (
     <Box h="100%" display="flex" flexDirection="column">
@@ -101,7 +151,12 @@ const EventFeed: React.FC<EventFeedProps> = ({
                         borderRadius="md" 
                         h="100%"
                       >
-                        <EventLogItemRenderer event={event} playerIndex={playerIndex} />
+                        <EventLogItemRenderer 
+                          event={event} 
+                          playerIndex={playerIndex}
+                          getWeaponName={getWeaponName}
+                          getArmorName={getArmorName}
+                        />
                       </Box>
                     </Box>
                   );

--- a/src/components/game/feed/EventLogItemRenderer.tsx
+++ b/src/components/game/feed/EventLogItemRenderer.tsx
@@ -9,6 +9,9 @@ interface EventLogItemRendererProps {
   event: domain.EventMessage; // Use the specific EventMessage type
   // Change prop to playerIndex
   playerIndex: number | null; 
+  // Add equipment name lookup functions
+  getWeaponName?: (weaponId: number) => string;
+  getArmorName?: (armorId: number) => string;
 }
 
 // Helper to get color based on type
@@ -52,7 +55,12 @@ const getEventTypeName = (type: domain.LogType | number): string => {
     }
 };
 
-export const EventLogItemRenderer: React.FC<EventLogItemRendererProps> = ({ event, playerIndex }) => {
+export const EventLogItemRenderer: React.FC<EventLogItemRendererProps> = ({ 
+  event, 
+  playerIndex, 
+  getWeaponName, 
+  getArmorName 
+}) => {
 
   // Use the helper function for the event type name
   const eventTypeName = getEventTypeName(event.type);
@@ -113,16 +121,17 @@ export const EventLogItemRenderer: React.FC<EventLogItemRendererProps> = ({ even
             [+{Number(event.details.experience)} XP].{" "}
           </chakra.span>
         )}
+        {/* Weapon looted */}
         {event.details.lootedWeaponID && Number(event.details.lootedWeaponID) > 0 && (
-          <chakra.span color="orange.300">
-            {" "}
-            [Looted Wpn {Number(event.details.lootedWeaponID)}].{" "}
+          <chakra.span color="yellow.400">
+            [Weapon: {getWeaponName ? getWeaponName(Number(event.details.lootedWeaponID)) : `Weapon ${Number(event.details.lootedWeaponID)}`}]. 
           </chakra.span>
         )}
+        
+        {/* Armor looted */}
         {event.details.lootedArmorID && Number(event.details.lootedArmorID) > 0 && (
-          <chakra.span color="orange.300">
-            {" "}
-            [Looted Arm {Number(event.details.lootedArmorID)}].{" "}
+          <chakra.span color="yellow.400">
+            [Armor: {getArmorName ? getArmorName(Number(event.details.lootedArmorID)) : `Armor ${Number(event.details.lootedArmorID)}`}]. 
           </chakra.span>
         )}
          {event.details.targetDied && (

--- a/src/components/game/feed/EventLogItemRenderer.tsx
+++ b/src/components/game/feed/EventLogItemRenderer.tsx
@@ -101,20 +101,29 @@ export const EventLogItemRenderer: React.FC<EventLogItemRendererProps> = ({ even
         {!event.details.hit && event.type === domain.LogType.Combat && (
           <chakra.span> Miss. </chakra.span>
         )}
-        {event.details.damageDone && event.details.damageDone > 0 && (
-          <chakra.span> [{event.details.damageDone} dmg]. </chakra.span>
+        {event.details.damageDone && Number(event.details.damageDone) > 0 && (
+          <chakra.span> [{Number(event.details.damageDone)} dmg]. </chakra.span>
         )}
-        {event.details.healthHealed && event.details.healthHealed > 0 && (
-          <chakra.span> [{event.details.healthHealed} heal]. </chakra.span>
+        {event.details.healthHealed && Number(event.details.healthHealed) > 0 && (
+          <chakra.span> [{Number(event.details.healthHealed)} heal]. </chakra.span>
         )}
-        {event.details.experience && event.details.experience > 0 && (
-          <chakra.span color="green.300"> [+{event.details.experience} XP]. </chakra.span>
+        {event.details.experience && Number(event.details.experience) > 0 && (
+          <chakra.span color="green.300">
+            {" "}
+            [+{Number(event.details.experience)} XP].{" "}
+          </chakra.span>
         )}
-        {event.details.lootedWeaponID && event.details.lootedWeaponID > 0 && (
-          <chakra.span color="orange.300"> [Looted Wpn {event.details.lootedWeaponID}]. </chakra.span>
+        {event.details.lootedWeaponID && Number(event.details.lootedWeaponID) > 0 && (
+          <chakra.span color="orange.300">
+            {" "}
+            [Looted Wpn {Number(event.details.lootedWeaponID)}].{" "}
+          </chakra.span>
         )}
-        {event.details.lootedArmorID && event.details.lootedArmorID > 0 && (
-          <chakra.span color="orange.300"> [Looted Arm {event.details.lootedArmorID}]. </chakra.span>
+        {event.details.lootedArmorID && Number(event.details.lootedArmorID) > 0 && (
+          <chakra.span color="orange.300">
+            {" "}
+            [Looted Arm {Number(event.details.lootedArmorID)}].{" "}
+          </chakra.span>
         )}
          {event.details.targetDied && (
           <chakra.span color="red.500" fontWeight="bold"> Target Died! </chakra.span>

--- a/src/components/game/layout/GameView.tsx
+++ b/src/components/game/layout/GameView.tsx
@@ -24,6 +24,10 @@ interface GameViewProps {
   isAttacking: boolean;
   isInCombat: boolean;
   isCacheLoading: boolean;
+  equipableWeaponIDs?: number[];
+  equipableWeaponNames?: string[];
+  equipableArmorIDs?: number[];
+  equipableArmorNames?: string[];
 }
 
 const GameView: React.FC<GameViewProps> = ({
@@ -39,7 +43,11 @@ const GameView: React.FC<GameViewProps> = ({
   isMoving,
   isAttacking,
   isInCombat,
-  isCacheLoading
+  isCacheLoading,
+  equipableWeaponIDs,
+  equipableWeaponNames,
+  equipableArmorIDs,
+  equipableArmorNames
 }) => {
   const [selectedTargetIndex, setSelectedTargetIndex] = useState<number | null>(null);
 
@@ -106,6 +114,10 @@ const GameView: React.FC<GameViewProps> = ({
             eventLogs={finalEventLogs}
             combatants={combatants}
             isCacheLoading={isCacheLoading}
+            equipableWeaponIDs={equipableWeaponIDs}
+            equipableWeaponNames={equipableWeaponNames}
+            equipableArmorIDs={equipableArmorIDs}
+            equipableArmorNames={equipableArmorNames}
           />
         </Box>
       </GridItem>


### PR DESCRIPTION
**Event Feed Equipment Names & DMG/HEAL amount Fix**

• Fixed dmg/ healing amt rendering: Combat damage/healing/XP amounts now display actual numbers instead of empty brackets (e.g., [252 dmg] vs [ dmg])
• Added equipment names display: Looted items now show actual names from contract instead of generic IDs (e.g., [Weapon: Silver Sword] vs [Weapon: 2])
• Added undefined fallbacks: Prevents crashes from undefined/null values with graceful fallbacks and error handling