### PR TITLE
fix: resolve BigInt overflow in balance shortfall display

### DIFF
--- a/src/components/WalletBalances.tsx
+++ b/src/components/WalletBalances.tsx
@@ -47,6 +47,9 @@ const WalletBalances: React.FC = () => {
   // State for action buttons
   const [isReplenishing, setIsReplenishing] = useState(false);
   const [isDirectFunding, setIsDirectFunding] = useState(false);
+
+  // Calculate shortfall amounts for display
+  const shortfallEth = shortfall && shortfall > BigInt(0) ? ethers.formatEther(shortfall) : '0';
   
   // Function to replenish session key balance using contract client
   const handleReplenishBalance = async (useMinimalAmount: boolean = false) => {
@@ -62,13 +65,8 @@ const WalletBalances: React.FC = () => {
         throw new Error('Owner wallet not connected.');
       }
       
-      // Convert shortfall to BigInt if it's not already
-      const shortfallBigInt = typeof shortfall === 'number' 
-        ? BigInt(Math.round(shortfall)) 
-        : shortfall;
-      
-      // Validate the shortfall
-      if (!shortfallBigInt || shortfallBigInt <= BigInt(0)) {
+      // Validate the shortfall (already in wei)
+      if (!shortfall || shortfall <= BigInt(0)) {
         throw new Error("No balance shortfall detected.");
       }
       
@@ -79,10 +77,10 @@ const WalletBalances: React.FC = () => {
       let targetAmount: bigint;
       if (useMinimalAmount) {
         // Minimal: just cover the shortfall
-        targetAmount = shortfallBigInt;
+        targetAmount = shortfall;
       } else {
         // Safe: shortfall + 50% buffer for safety
-        targetAmount = shortfallBigInt + (shortfallBigInt / BigInt(2));
+        targetAmount = shortfall + (shortfall / BigInt(2));
       }
       
       // Calculate safe replenish amount
@@ -187,8 +185,6 @@ const WalletBalances: React.FC = () => {
   const smallFundingAmount = (parseFloat(DIRECT_FUNDING_AMOUNT) * 0.5).toFixed(1);
   const largeFundingAmount = DIRECT_FUNDING_AMOUNT;
   
-  // Calculate shortfall amounts for display
-  const shortfallEth = shortfall ? ethers.formatEther(shortfall) : '0';
   const shortfallNum = parseFloat(shortfallEth);
   const safeReplenishAmount = (shortfallNum * 1.5).toFixed(4);
   

--- a/src/hooks/game/useGame.ts
+++ b/src/hooks/game/useGame.ts
@@ -281,7 +281,7 @@ export const useGame = () => {
       noncombatants: liveGameState.noncombatants || [],
       eventLogs: liveGameState.eventLogs || [], // Using only live events for now
       chatLogs: uniqueChatLogs, // Use combined, unique, sorted chat logs
-      balanceShortfall: liveGameState.balanceShortfall || 0,
+      balanceShortfall: liveGameState.balanceShortfall || BigInt(0),
       unallocatedAttributePoints: liveGameState.unallocatedAttributePoints || 0,
       lastBlock: liveGameState.lastBlock || 0
     };

--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -57,8 +57,9 @@ export function useWalletBalances(owner: string | null) {
     : '0';
     
   const shortfall = hasValidSessionKeyData ? (gameState.balanceShortfall || BigInt(0)) : BigInt(0);
+  
   // Only format if shortfall is positive AND session key data was valid
-  const formattedShortfall = hasValidSessionKeyData && shortfall > 0 ? ethers.formatUnits(BigInt(shortfall), 18) : '0'; 
+  const formattedShortfall = hasValidSessionKeyData && shortfall > 0 ? ethers.formatEther(shortfall) : '0'; 
   
   // Determine if the session key balance is below threshold
   const targetBalance = hasValidSessionKeyData ? (gameState.sessionKeyData?.targetBalance || BigInt(0)) : BigInt(0);

--- a/src/mappers/contractToDomain.ts
+++ b/src/mappers/contractToDomain.ts
@@ -596,7 +596,7 @@ export function contractToWorldSnapshot(
     noncombatants: (raw.noncombatants || []).map(mapCharacterLite),
     eventLogs: allEventLogs,
     chatLogs: allChatMessages,
-    balanceShortfall: Number(raw.balanceShortfall || 0),
+    balanceShortfall: raw.balanceShortfall || BigInt(0),
     unallocatedAttributePoints: Number(raw.unallocatedAttributePoints || 0),
     lastBlock: Number(raw.endBlock || 0)
   };

--- a/src/mappers/domainToUi.ts
+++ b/src/mappers/domainToUi.ts
@@ -3,6 +3,7 @@
  * This centralizes all transformation logic between the domain and UI layers
  */
 
+import { ethers } from 'ethers';
 import { domain, ui } from '@/types';
 import { DEFAULT_SESSION_KEY_DATA } from '@/types/domain';
 
@@ -72,7 +73,7 @@ export function worldSnapshotToGameState(
     equipableArmorIDs: [],
     equipableArmorNames: [],
     unallocatedAttributePoints: snapshot.unallocatedAttributePoints,
-    balanceShortfall: snapshot.balanceShortfall,
+    balanceShortfall: Number(ethers.formatEther(snapshot.balanceShortfall)),
     updates,
     loading: false,
     error: null

--- a/src/mappers/index.ts
+++ b/src/mappers/index.ts
@@ -36,7 +36,7 @@ export function contractToGameState(
       noncombatants: [],
       eventLogs: [],
       chatLogs: [],
-      balanceShortfall: 0,
+      balanceShortfall: BigInt(0),
       unallocatedAttributePoints: 0,
       lastBlock: 0
     };

--- a/src/types/domain/worldSnapshot.ts
+++ b/src/types/domain/worldSnapshot.ts
@@ -19,7 +19,7 @@ export interface WorldSnapshot {
   noncombatants: CharacterLite[];
   eventLogs: EventMessage[];
   chatLogs: ChatMessage[];
-  balanceShortfall: number;
+  balanceShortfall: bigint;
   unallocatedAttributePoints: number;
   
   // Tracking


### PR DESCRIPTION
- Keep balanceShortfall as bigint throughout data pipeline
- Fix double conversion issue that caused ethers.formatEther() overflow
- Convert wei to ether only in UI layer, not in domain mapping
- Resolves TypeError when displaying balance shortfall of ~0.093 ETH