### PR TITLE
Fix/character class mapping

### DIFF
--- a/src/blockchain/abis/BattleNadsEntrypoint.json
+++ b/src/blockchain/abis/BattleNadsEntrypoint.json
@@ -21,6 +21,45 @@
     },
     {
         "type": "function",
+        "name": "ADDRESS_HUB",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "ATLAS",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "GENERAL_TASK_IMPL",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
         "name": "POLICY_ID",
         "inputs": [],
         "outputs": [
@@ -174,6 +213,29 @@
                 "name": "newLuck",
                 "type": "uint256",
                 "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "areaCleanUp",
+        "inputs": [
+            {
+                "name": "depth",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "x",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "y",
+                "type": "uint8",
+                "internalType": "uint8"
             }
         ],
         "outputs": [],
@@ -507,8 +569,8 @@
         "outputs": [
             {
                 "name": "",
-                "type": "address",
-                "internalType": "address"
+                "type": "bytes32",
+                "internalType": "bytes32"
             }
         ],
         "stateMutability": "view"
@@ -550,6 +612,55 @@
             }
         ],
         "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "createCharacter",
+        "inputs": [
+            {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+            },
+            {
+                "name": "strength",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "vitality",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "dexterity",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "quickness",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "sturdiness",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "luck",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "characterID",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "payable"
     },
     {
         "type": "function",
@@ -6360,6 +6471,25 @@
     },
     {
         "type": "function",
+        "name": "killMap",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
         "name": "logs",
         "inputs": [
             {
@@ -7755,31 +7885,6 @@
         "anonymous": false
     },
     {
-        "type": "event",
-        "name": "TaskNotScheduled",
-        "inputs": [
-            {
-                "name": "maxPayment",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            },
-            {
-                "name": "amountEstimated",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            },
-            {
-                "name": "targetBlock",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
         "type": "error",
         "name": "AbilityCantHaveTarget",
         "inputs": []
@@ -7895,11 +8000,6 @@
                 "internalType": "bytes32"
             }
         ]
-    },
-    {
-        "type": "error",
-        "name": "CantMoveInCombat",
-        "inputs": []
     },
     {
         "type": "error",
@@ -8127,19 +8227,8 @@
     },
     {
         "type": "error",
-        "name": "InvalidTaskCostEstimate",
-        "inputs": [
-            {
-                "name": "amountEstimated",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "executionCost",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ]
+        "name": "InvalidTaskOwner",
+        "inputs": []
     },
     {
         "type": "error",
@@ -8232,22 +8321,6 @@
     },
     {
         "type": "error",
-        "name": "SessionKeyExpired",
-        "inputs": [
-            {
-                "name": "expiration",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "currentBlock",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ]
-    },
-    {
-        "type": "error",
         "name": "SessionKeyMonTransferFailed",
         "inputs": [
             {
@@ -8275,12 +8348,34 @@
     },
     {
         "type": "error",
-        "name": "TaskNotRescheduled",
-        "inputs": []
+        "name": "TaskDeadlineInvalid",
+        "inputs": [
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
     },
     {
         "type": "error",
-        "name": "TaskNotScheduled",
+        "name": "TaskExpired",
+        "inputs": [
+            {
+                "name": "expiration",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "currentBlock",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "TaskNotRescheduled",
         "inputs": []
     },
     {
@@ -8295,7 +8390,7 @@
     },
     {
         "type": "error",
-        "name": "UnknownMsgSender",
+        "name": "UnknownMsgSenderType",
         "inputs": []
     },
     {

--- a/src/blockchain/adapters/BattleNadsAdapter.ts
+++ b/src/blockchain/adapters/BattleNadsAdapter.ts
@@ -362,31 +362,31 @@ export class BattleNadsAdapter {
  */
 function getClassSpecificAbilityIndex(ability: domain.Ability): number {
   switch (ability) {
-    // Bard abilities (class 0)
+    // Bard abilities (class 4)
     case domain.Ability.SingSong:
       return 1;
     case domain.Ability.DoDance:
       return 2;
     
-    // Warrior abilities (class 4)
+    // Warrior abilities (class 5)
     case domain.Ability.ShieldBash:
       return 1;
     case domain.Ability.ShieldWall:
       return 2;
     
-    // Rogue abilities (class 5)
+    // Rogue abilities (class 6)
     case domain.Ability.EvasiveManeuvers:
       return 1;
     case domain.Ability.ApplyPoison:
       return 2;
     
-    // Monk abilities (class 6)
+    // Monk abilities (class 7)
     case domain.Ability.Pray:
       return 1;
     case domain.Ability.Smite:
       return 2;
     
-    // Sorcerer abilities (class 7)
+    // Sorcerer abilities (class 8)
     case domain.Ability.ChargeUp:
       return 1;
     case domain.Ability.Fireball:
@@ -426,6 +426,7 @@ function getAbilitiesForCharacterClass(characterClass: domain.CharacterClass): d
     case domain.CharacterClass.Basic:
     case domain.CharacterClass.Elite:
     case domain.CharacterClass.Boss:
+    case domain.CharacterClass.Null:
     default:
       return []; // Monsters or unhandled classes have no usable abilities
   }

--- a/src/components/game/controls/AbilityControls.tsx
+++ b/src/components/game/controls/AbilityControls.tsx
@@ -60,12 +60,12 @@ export const AbilityControls: React.FC<AbilityControlsProps> = ({
         duration: 3000,
         isClosable: true,
       });
-      console.warn(`Ability ${abilityIndex} requires a target, but none selected or target invalid.`);
       return;
     }
     
     // Use the position index directly for abilities that require targets
-    useAbility(abilityIndex, requiresTarget ? selectedTargetIndex : 0);
+    const finalTargetIndex = requiresTarget ? selectedTargetIndex : 0;
+    useAbility(abilityIndex, finalTargetIndex);
   };
 
   const handleAttack = () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,7 +4,9 @@
  */
 
 // Contract addresses
-export const ENTRYPOINT_ADDRESS = process.env.NEXT_PUBLIC_ENTRYPOINT_ADDRESS || '0x6a5b12B54921d023d3537caa210dCfFEB2f4A253'; // Policy 30
+export const ENTRYPOINT_ADDRESS = process.env.NEXT_PUBLIC_ENTRYPOINT_ADDRESS || '0xfd6354B61Ac348226dB816192D00Ab7fCF984169'; // Policy 33
+
+//'0x6a5b12B54921d023d3537caa210dCfFEB2f4A253'; // Policy 30
 
 
 // to many dead bodies 

--- a/src/hooks/game/useAbilityCooldowns.ts
+++ b/src/hooks/game/useAbilityCooldowns.ts
@@ -271,6 +271,8 @@ export const useAbilityCooldowns = (characterId: string | null) => {
  */
 function getAbilitiesForClass(characterClass: domain.CharacterClass): domain.Ability[] {
   switch (characterClass) {
+    case domain.CharacterClass.Bard:
+      return [domain.Ability.SingSong, domain.Ability.DoDance];
     case domain.CharacterClass.Warrior:
       return [domain.Ability.ShieldBash, domain.Ability.ShieldWall];
     case domain.CharacterClass.Rogue:
@@ -279,12 +281,10 @@ function getAbilitiesForClass(characterClass: domain.CharacterClass): domain.Abi
       return [domain.Ability.Pray, domain.Ability.Smite];
     case domain.CharacterClass.Sorcerer:
       return [domain.Ability.Fireball, domain.Ability.ChargeUp];
-    case domain.CharacterClass.Bard:
-      return [domain.Ability.SingSong, domain.Ability.DoDance];
-    // Add other classes if they exist
-    // case domain.CharacterClass.Basic:
-    // case domain.CharacterClass.Elite:
-    // case domain.CharacterClass.Boss:
+    case domain.CharacterClass.Basic:
+    case domain.CharacterClass.Elite:
+    case domain.CharacterClass.Boss:
+    case domain.CharacterClass.Null:
     default:
       return []; // Monsters or unhandled classes have no usable abilities
   }

--- a/src/types/domain/enums.ts
+++ b/src/types/domain/enums.ts
@@ -6,16 +6,17 @@
 // Match the contract's CharacterClass enum
 export enum CharacterClass {
   // Null value
-  Bard = 0,
+  Null = 0,
   // Monsters
   Basic = 1,
   Elite = 2,
   Boss = 3,
   // Player Classes
-  Warrior = 4,
-  Rogue = 5,
-  Monk = 6,
-  Sorcerer = 7
+  Bard = 4,
+  Warrior = 5,
+  Rogue = 6,
+  Monk = 7,
+  Sorcerer = 8
 }
 
 // Match the contract's StatusEffect enum


### PR DESCRIPTION
# Fix CharacterClass enum mismatch breaking ability targeting

Fixes abilities failing with "invalid index" errors - turns out the frontend enum was completely wrong.

## Problem
Frontend `CharacterClass` enum values didn't match the contract at all:
- Frontend: Bard=0, Warrior=4, Rogue=5, Monk=6, Sorcerer=7  
- Contract: Bard=4, Warrior=5, Rogue=6, Monk=7, Sorcerer=8

This broke `getClassSpecificAbilityIndex()` which was mapping abilities to wrong character classes, causing the contract to reject ability calls.

## Changes
- Fixed enum values in `src/types/domain/enums.ts` to match contract exactly
- Updated ability mappings in `BattleNadsAdapter.ts` and `useAbilityCooldowns.ts`
- Added missing `Null=0` case that was missing
- Updated class number comments (were saying "class 0" instead of "class 4" etc)