### PR TITLE
feat: display non-combatants and enable attacking them

### DIFF
--- a/src/components/game/GameContainer.tsx
+++ b/src/components/game/GameContainer.tsx
@@ -171,6 +171,7 @@ const GameContainer: React.FC<GameContainerProps> = (props) => {
           character={character}
           position={position}
           combatants={gameState?.combatants || []}
+          noncombatants={gameState?.noncombatants || []}
           chatLogs={gameState?.chatLogs || []}
           eventLogs={gameState?.eventLogs || []}
           onMove={handleMovement}

--- a/src/components/game/controls/CombatTargets.tsx
+++ b/src/components/game/controls/CombatTargets.tsx
@@ -5,109 +5,142 @@ import HealthBar from '../ui/HealthBar';
 
 interface CombatTargetsProps {
   combatants: domain.CharacterLite[];
+  noncombatants: domain.CharacterLite[];
   selectedTargetIndex: number | null;
   onSelectTarget: (index: number | null) => void;
 }
 
 const CombatTargets: React.FC<CombatTargetsProps> = ({ 
   combatants, 
+  noncombatants,
   selectedTargetIndex,
   onSelectTarget
 }) => {
   // Filter out dead characters from combat targets to prevent targeting dead enemies
   const validCombatants = combatants.filter(combatant => !combatant.isDead);
   
+  // Filter out dead characters from non-combatants as well
+  const validNoncombatants = noncombatants.filter(noncombatant => !noncombatant.isDead);
+  
   // Get the character class name
   const getClassDisplayName = (classValue: domain.CharacterClass): string => {
     return domain.CharacterClass[classValue] || 'Unknown';
+  };
+  
+  // Render character button component
+  const renderCharacterButton = (character: domain.CharacterLite, arrayIndex: number, isNoncombatant: boolean = false) => {
+    // Use the character's position index for targeting, not array index
+    const positionIndex = character.index;
+    const isSelected = selectedTargetIndex === positionIndex;
+    
+    return (
+      <Button
+        key={character.id} // Use character ID as key for stability
+        size="sm"
+        variant={isSelected ? "solid" : "ghost"}
+        colorScheme={isSelected ? "whiteAlpha" : "gray"}
+        justifyContent="flex-start"
+        width="100%"
+        mb={1}
+        p={3}
+        h="auto"
+        onClick={() => onSelectTarget(isSelected ? null : positionIndex)}
+        flexDirection="column"
+        alignItems="stretch"
+        opacity={isNoncombatant ? 0.7 : 1}
+        border={isNoncombatant ? "1px dashed" : "1px solid"}
+        borderColor={isNoncombatant ? "gray.500" : "transparent"}
+      >
+        {/* Top row: Name, Class, Level */}
+        <Flex justify="space-between" align="center" w="100%" mb={2}>
+          <Flex align="center" gap={2}>
+            <Text fontSize="sm" className={isNoncombatant ? 'text-gray-300' : 'gold-text-light'}>
+              {character.name || `${isNoncombatant ? 'Player' : 'Enemy'} #${arrayIndex + 1}`}
+            </Text>
+            {isNoncombatant && (
+              <Text fontSize="xs" className="text-gray-400 italic">
+                (non-combatant)
+              </Text>
+            )}
+          </Flex>
+          <Flex gap={1}>
+            <Box 
+              backgroundImage="/assets/bg/level.png"
+              backgroundSize="contain"
+              backgroundRepeat="no-repeat"
+              backgroundPosition="center"
+              px={2}
+              py={1}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              minWidth="60px"
+              height="24px"
+              className={isNoncombatant ? 'text-gray-400 text-center font-serif text-sm' : 'text-yellow-400/90 text-center font-serif text-sm'}
+            >
+              {getClassDisplayName(character.class)}
+            </Box>
+            <Box 
+              backgroundImage="/assets/bg/level.png"
+              backgroundSize="contain"
+              backgroundRepeat="no-repeat"
+              backgroundPosition="center"
+              px={2}
+              py={1}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              minWidth="50px"
+              height="24px"
+              className={isNoncombatant ? 'text-gray-400 text-center font-serif text-sm' : 'text-yellow-400/90 text-center font-serif text-sm'}
+            >
+              Lvl {character.level || '?'}
+            </Box>
+          </Flex>
+        </Flex>
+        
+        {/* Bottom row: Health Bar */}
+        <Box w="100%">
+          <HealthBar 
+            health={character.health}
+            maxHealth={character.maxHealth}
+            size="small"
+            showLabel={true}
+          />
+        </Box>
+      </Button>
+    );
   };
   
   return (
     <Box h="100%" display="flex" flexDirection="column">
       <h2 className='uppercase gold-text-light text-2xl font-bold tracking-tight mb-2 text-center'>Combat</h2>
       
-      {validCombatants.length === 0 ? (
+      {validCombatants.length === 0 && validNoncombatants.length === 0 ? (
         <Box className="flex items-center justify-center h-full w-full bg-dark-brown rounded-md">
           <Text className='gold-text-light text-lg'>No targets in this area</Text>
         </Box>
       ) : (
         <VStack spacing={2} align="stretch">
-          {/* Target List */}
-          <Box p={2} borderRadius="md" mb={2} overflowY="auto" className='bg-dark-brown'>
-            {validCombatants.map((combatant, arrayIndex) => {
-              // Use the character's position index for targeting, not array index
-              const positionIndex = combatant.index;
-              const isSelected = selectedTargetIndex === positionIndex;
-              
-              return (
-                <Button
-                key={combatant.id} // Use character ID as key for stability
-                size="sm"
-                variant={isSelected ? "solid" : "ghost"}
-                colorScheme={isSelected ? "whiteAlpha" : "gray"}
-                justifyContent="flex-start"
-                width="100%"
-                mb={1}
-                p={3}
-                h="auto"
-                onClick={() => onSelectTarget(isSelected ? null : positionIndex)}
-                flexDirection="column"
-                alignItems="stretch"
-                >
-                  {/* Top row: Name, Class, Level */}
-                  <Flex justify="space-between" align="center" w="100%" mb={2}>
-                    <Text fontSize="sm" className='gold-text-light'>
-                      {combatant.name || `Enemy #${arrayIndex + 1}`}
-                    </Text>
-                    <Flex gap={1}>
-                      <Box 
-                      backgroundImage="/assets/bg/level.png"
-                      backgroundSize="contain"
-                      backgroundRepeat="no-repeat"
-                      backgroundPosition="center"
-                      px={2}
-                      py={1}
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      minWidth="60px"
-                      height="24px"
-                      className='text-yellow-400/90 text-center font-serif text-sm'
-                      >
-                        {getClassDisplayName(combatant.class)}
-                      </Box>
-                      <Box 
-                      backgroundImage="/assets/bg/level.png"
-                      backgroundSize="contain"
-                      backgroundRepeat="no-repeat"
-                      backgroundPosition="center"
-                      px={2}
-                      py={1}
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      minWidth="50px"
-                      height="24px"
-                      className='text-yellow-400/90 text-center font-serif text-sm'
-                      >
-                        Lvl {combatant.level || '?'}
-                      </Box>
-                    </Flex>
-                  </Flex>
-                  
-                  {/* Bottom row: Health Bar */}
-                  <Box w="100%">
-                    <HealthBar 
-                      health={combatant.health}
-                      maxHealth={combatant.maxHealth}
-                      size="small"
-                      showLabel={true}
-                    />
-                  </Box>
-                </Button>
-              );
-            })}
-          </Box>
+          {/* Combatants Section */}
+          {validCombatants.length > 0 && (
+            <Box p={2} borderRadius="md" mb={2} overflowY="auto" className='bg-dark-brown'>
+              <Text className='gold-text-light text-sm font-bold mb-2 uppercase tracking-wide'>Active Combatants</Text>
+              {validCombatants.map((combatant, arrayIndex) => 
+                renderCharacterButton(combatant, arrayIndex, false)
+              )}
+            </Box>
+          )}
+          
+          {/* Non-Combatants Section */}
+          {validNoncombatants.length > 0 && (
+            <Box p={2} borderRadius="md" mb={2} overflowY="auto" className='bg-dark-brown/50'>
+              <Text className='text-gray-300 text-sm font-bold mb-2 uppercase tracking-wide'>Other Players</Text>
+              {validNoncombatants.map((noncombatant, arrayIndex) => 
+                renderCharacterButton(noncombatant, arrayIndex, true)
+              )}
+            </Box>
+          )}
         </VStack>
       )}
     </Box>

--- a/src/components/game/layout/GameView.tsx
+++ b/src/components/game/layout/GameView.tsx
@@ -111,6 +111,7 @@ const GameView: React.FC<GameViewProps> = ({
           character={character}
           position={position}
           combatants={combatants}
+          noncombatants={noncombatants}
           selectedTargetIndex={selectedTargetIndex}
           setSelectedTargetIndex={handleSelectTarget}
           onMove={onMove}

--- a/src/components/game/layout/GameView.tsx
+++ b/src/components/game/layout/GameView.tsx
@@ -14,6 +14,7 @@ interface GameViewProps {
   character: domain.Character;
   position: { x: number; y: number; z: number };
   combatants: domain.CharacterLite[];
+  noncombatants: domain.CharacterLite[];
   chatLogs: domain.ChatMessage[];
   eventLogs: domain.EventMessage[];
   onMove: (direction: 'north' | 'south' | 'east' | 'west' | 'up' | 'down') => Promise<void>;
@@ -34,6 +35,7 @@ const GameView: React.FC<GameViewProps> = ({
   character,
   position,
   combatants,
+  noncombatants,
   chatLogs,
   eventLogs,
   onMove,
@@ -126,7 +128,8 @@ const GameView: React.FC<GameViewProps> = ({
           {/* Combat Panel */}
             <Box borderRadius="md" className='h-full card-bg p-4 flex flex-col'>
             <CombatTargets 
-              combatants={combatants} 
+              combatants={combatants}
+              noncombatants={noncombatants}
               selectedTargetIndex={selectedTargetIndex}
               onSelectTarget={handleSelectTarget}
             />

--- a/src/components/game/ui/CharacterActionsTabs.tsx
+++ b/src/components/game/ui/CharacterActionsTabs.tsx
@@ -10,6 +10,7 @@ interface CharacterActionsTabsProps {
   character: domain.Character;
   position: { x: number; y: number; z: number };
   combatants: domain.CharacterLite[];
+  noncombatants: domain.CharacterLite[];
   selectedTargetIndex: number | null;
   setSelectedTargetIndex: (index: number | null) => void;
   onMove: (direction: 'north' | 'south' | 'east' | 'west' | 'up' | 'down') => Promise<void>;
@@ -25,6 +26,7 @@ const CharacterActionsTabs: React.FC<CharacterActionsTabsProps> = ({
   character,
   position,
   combatants,
+  noncombatants,
   selectedTargetIndex,
   setSelectedTargetIndex,
   onMove,
@@ -135,6 +137,7 @@ const CharacterActionsTabs: React.FC<CharacterActionsTabsProps> = ({
                 onAttack={onAttack}
                 isAttacking={isAttacking}
                 combatants={combatants.filter(combatant => !combatant.isDead)}
+                noncombatants={noncombatants.filter(noncombatant => !noncombatant.isDead)}
               />
             ) : (
               <AbilityControls 
@@ -144,6 +147,7 @@ const CharacterActionsTabs: React.FC<CharacterActionsTabsProps> = ({
                 onAttack={onAttack}
                 isAttacking={isAttacking}
                 combatants={combatants.filter(combatant => !combatant.isDead)}
+                noncombatants={noncombatants.filter(noncombatant => !noncombatant.isDead)}
               />
             )}
           </Box>


### PR DESCRIPTION
## Summary
- Display non-combatants in combat panel with visual distinction from active combatants
- Enable attacking non-combatants to initiate combat regardless of current combat state
- Maintain existing attack restrictions for combatants (must be in combat)

## Changes Made
- **CombatTargets Component**: Added noncombatants display with reduced opacity, dashed borders, and gray styling
- **AbilityControls Component**: Enhanced target validation to support both combatants and non-combatants with separate attack logic
- **Attack System**: Allow attacking non-combatants outside of combat while preserving combatant restrictions
- **Component Data Flow**: Pass noncombatants data through GameView → CharacterActionsTabs → AbilityControls

## Visual Features
- Non-combatants displayed with "(non-combatant)" label and distinct styling
- Separate sections for "Active Combatants" and "Other Players"  
- Clear attack button status messages for different target types

## Test Plan
- [x] Build passes with no TypeScript errors
- [x] All existing tests continue to pass (78/78)
- [x] Attack button enables for non-combatants regardless of combat state
- [x] Attack button maintains combat requirement for active combatants
- [x] Visual distinction between combatants and non-combatants is clear
- [ ] Manual testing: attacking non-combatant moves them to combatants list