### PR TITLE
fix: improve wallet balance UI - remove spinner and fix currency display

### DIFF
--- a/src/components/WalletBalances.tsx
+++ b/src/components/WalletBalances.tsx
@@ -5,7 +5,6 @@ import {
   Flex, 
   Badge,  
   Button,
-  Spinner,
   useToast
 } from '@chakra-ui/react';
 import { ethers } from 'ethers';
@@ -155,17 +154,7 @@ const WalletBalances: React.FC = () => {
     }
   };
 
-  // Show loading state if data is not ready
-  if (isLoading) {
-    return (
-      <Box p={4} borderWidth="1px" borderRadius="lg" color="white">
-        <Flex justify="center" align="center" minH="100px">
-          <Spinner mr={3} />
-          <Text>Loading wallet balances...</Text>
-        </Flex>
-      </Box>
-    );
-  }
+  // Note: Removed loading spinner - balances update in background
   
   // Handle error state
   if (gameStateError) {

--- a/src/components/WalletBalances.tsx
+++ b/src/components/WalletBalances.tsx
@@ -185,7 +185,7 @@ const WalletBalances: React.FC = () => {
         <div className='flex w-full justify-between gap-2'>
           <Flex align="center" gap={1}>
             <h2 className='text-sm font-medium gold-text-light'>Session Key</h2>
-            <Badge colorScheme="yellow" size="xs">shMON</Badge>
+            <Badge colorScheme="yellow" size="xs">MON</Badge>
           </Flex>
           <div className='font-semibold text-amber-300 text-sm'>
           {parseFloat(sessionKeyBalance).toFixed(4)}


### PR DESCRIPTION
## Summary
Improves the wallet balance UI by removing the loading spinner and fixing the Session Key currency display.

## Changes Made
- **Remove Balance Refresh Spinner**: Eliminated loading spinner from WalletBalances component UI
- **Fix Session Key Currency**: Changed Session Key balance display from shMON to MON
- **Background Updates**: Balances now update seamlessly in background without UI interruption

## Technical Details
### Spinner Removal
- Removed loading state UI that showed "Loading wallet balances..." with spinner
- Component now shows default values initially ("0.0000") and updates seamlessly
- Balance updates continue working in background without user-facing loading states

### Currency Fix
- Session Key balance now correctly shows **MON** badge instead of shMON
- Committed balance remains as **shMON** (bonded shares)
- Aligns display with actual token denomination

## User Experience Impact
- **No UI interruptions** during balance refresh
- **Continuous balance updates** without loading states
- **Correct currency labeling** for better clarity
- **Faster perceived performance** with immediate UI display

## Test Plan
- [x] Verify balances show immediately on page load
- [x] Confirm balances update in background without spinner
- [x] Check Session Key shows "MON" currency
- [x] Verify Committed balance still shows "shMON"
- [x] Test balance refresh functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)