### PR TITLE
Fix TypeScript compilation errors in test files

### DIFF
--- a/src/blockchain/adapters/__tests__/BattleNadsAdapter.test.ts
+++ b/src/blockchain/adapters/__tests__/BattleNadsAdapter.test.ts
@@ -109,10 +109,13 @@ describe('BattleNadsAdapter', () => {
     
     it('returns correct data structure', async () => {
       const mockReturn: ContractTypes.SessionKeyData = {
+        owner: '0xOwner',
         key: '0xSessionKey',
+        balance: 1000n,
+        targetBalance: 2000n,
+        ownerCommittedAmount: 500n,
+        ownerCommittedShares: 100n,
         expiration: 9999999n,
-        isValid: true,
-        // No 'balance' property expected here
       };
       mockContractMethods.getCurrentSessionKeyData.mockResolvedValueOnce(mockReturn);
       

--- a/src/hooks/game/__tests__/useCachedDataFeed.test.tsx
+++ b/src/hooks/game/__tests__/useCachedDataFeed.test.tsx
@@ -68,11 +68,11 @@ describe('useCachedDataFeed', () => {
     };
     
     // Mock all database tables
-    mockDb.events.where.mockReturnValue(mockWhere as any);
-    mockDb.chatMessages.where.mockReturnValue(mockWhere as any);
-    mockDb.dataBlocks.where.mockReturnValue(mockWhere as any);
-    mockDb.characters.put.mockResolvedValue(undefined as any);
-    mockDb.transaction.mockImplementation(async (mode, tables, callback) => {
+    (mockDb.events.where as jest.Mock).mockReturnValue(mockWhere as any);
+    (mockDb.chatMessages.where as jest.Mock).mockReturnValue(mockWhere as any);
+    (mockDb.dataBlocks.where as jest.Mock).mockReturnValue(mockWhere as any);
+    (mockDb.characters.put as jest.Mock).mockResolvedValue(undefined as any);
+    (mockDb.transaction as jest.Mock).mockImplementation(async (mode: any, tables: any, callback: any) => {
       return await callback();
     });
   });
@@ -134,7 +134,7 @@ describe('useCachedDataFeed', () => {
       }),
     };
     
-    mockDb.dataBlocks.where.mockReturnValue(mockWhere as any);
+    (mockDb.dataBlocks.where as jest.Mock).mockReturnValue(mockWhere as any);
 
     const { result } = renderHook(() => useCachedDataFeed(mockOwner, mockCharacterId), {
       wrapper: createWrapper(),
@@ -165,7 +165,7 @@ describe('useCachedDataFeed', () => {
       }),
     };
     
-    mockDb.dataBlocks.where.mockReturnValue(mockWhere as any);
+    (mockDb.dataBlocks.where as jest.Mock).mockReturnValue(mockWhere as any);
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -216,8 +216,8 @@ describe('storeEventData', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDb.events.add.mockResolvedValue(undefined as any);
-    mockDb.chatMessages.add.mockResolvedValue(undefined as any);
+    (mockDb.events.add as jest.Mock).mockResolvedValue(undefined as any);
+    (mockDb.chatMessages.add as jest.Mock).mockResolvedValue(undefined as any);
     
     // Mock first() to return null (no existing events)
     const mockWhere = {
@@ -225,10 +225,10 @@ describe('storeEventData', () => {
         first: jest.fn().mockResolvedValue(null),
       }),
     };
-    mockDb.events.where.mockReturnValue(mockWhere as any);
-    mockDb.chatMessages.where.mockReturnValue(mockWhere as any);
+    (mockDb.events.where as jest.Mock).mockReturnValue(mockWhere as any);
+    (mockDb.chatMessages.where as jest.Mock).mockReturnValue(mockWhere as any);
     
-    mockDb.transaction.mockImplementation(async (mode, tables, callback) => {
+    (mockDb.transaction as jest.Mock).mockImplementation(async (mode: any, tables: any, callback: any) => {
       return await callback();
     });
   });
@@ -269,7 +269,7 @@ describe('storeEventData', () => {
   });
 
   it('should handle database storage errors', async () => {
-    mockDb.events.add.mockRejectedValue(new Error('Storage error'));
+    (mockDb.events.add as jest.Mock).mockRejectedValue(new Error('Storage error'));
     
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 

--- a/src/mappers/__tests__/mappers.test.ts
+++ b/src/mappers/__tests__/mappers.test.ts
@@ -34,8 +34,9 @@ describe('Data Mappers', () => {
       const result = contractToWorldSnapshot(mockPollData as any, '0xOwnerAddress');
       
       // Basic assertions that focus on functionality
-      expect(result.characterID).toBe(mockPollData.characterID);
-      expect(result.sessionKeyData.key).toBe(mockPollData.sessionKeyData.key);
+      expect(result).toBeDefined();
+      expect(result?.characterID).toBe(mockPollData.characterID);
+      expect(result?.sessionKeyData?.key).toBe(mockPollData.sessionKeyData.key);
     });
   });
 }); 

--- a/src/utils/__tests__/areaId.test.ts
+++ b/src/utils/__tests__/areaId.test.ts
@@ -68,12 +68,12 @@ describe('Area ID utilities', () => {
     });
 
     it('should reject invalid area IDs', () => {
-      expect(isValidAreaID('')).toBe(false);
-      expect(isValidAreaID('invalid')).toBe(false);
-      expect(isValidAreaID(123)).toBe(false); // number instead of bigint
+      expect(isValidAreaID('' as any)).toBe(false);
+      expect(isValidAreaID('invalid' as any)).toBe(false);
+      expect(isValidAreaID(123 as any)).toBe(false); // number instead of bigint
       expect(isValidAreaID(-1n)).toBe(false); // negative bigint
-      expect(isValidAreaID(null)).toBe(false);
-      expect(isValidAreaID(undefined)).toBe(false);
+      expect(isValidAreaID(null as any)).toBe(false);
+      expect(isValidAreaID(undefined as any)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #117

## Summary

This PR resolves all 21 TypeScript compilation errors that were occurring in test files when running `npx tsc --noEmit`. The project has `"strict": true` enabled, which was catching type safety issues in test code.

## Changes Made

### 1. BigInt Type Errors (5 errors fixed)
- **File**: `src/utils/__tests__/areaId.test.ts`
- **Fix**: Added type assertions (`as any`) for test cases that intentionally pass invalid types to validate error handling

### 2. Jest Mock Type Errors (12 errors fixed)
- **File**: `src/hooks/game/__tests__/useCachedDataFeed.test.tsx`
- **Fix**: Properly typed all mock function calls using `(mockFunction as jest.Mock)` to enable Jest mock methods

### 3. Null Check Errors (3 errors fixed)
- **File**: `src/mappers/__tests__/mappers.test.ts`
- **Fix**: Added proper null checks and optional chaining operators for potentially null values

### 4. Interface Mismatch Error (1 error fixed)
- **File**: `src/blockchain/adapters/__tests__/BattleNadsAdapter.test.ts`
- **Fix**: Removed invalid `isValid` property and added all required `SessionKeyData` interface properties

## Test Plan

- [x] Run `npx tsc --noEmit` - No errors
- [x] Run `npm test` - All 201 tests pass
- [x] Run `npm run build` - Build succeeds

## Impact

- ✅ **Production code**: Not affected - all changes are in test files only
- ✅ **CI/CD**: TypeScript compilation checks will now pass
- ✅ **Developer experience**: Clean `tsc` output during development
- ✅ **Type safety**: Maintained proper typing in test scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)