### PR TITLE
feat: consolidate Weapon and Armor types using base interfaces (Part 2 of 5)

### DIFF
--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -21,10 +21,10 @@ export interface BaseWeapon<T = number> {
  */
 export interface BaseArmor<T = number> {
   name: string;
-  defense: T;
-  magicResist: T;
-  health: T;
-  evasion: T;
+  armorFactor: T;
+  armorQuality: T;
+  flexibility: T;
+  weight: T;
 }
 
 /**

--- a/src/types/contract/BattleNads.ts
+++ b/src/types/contract/BattleNads.ts
@@ -1,6 +1,8 @@
 // Raw Solidity contract types for BattleNads
 // These types exactly match the on-chain structures and use appropriate primitive types
 
+import { BaseWeapon, BaseArmor } from '@/types/base';
+
 // Session key data structure (Matches CashierTypes.SessionKeyData)
 export interface SessionKeyData {
   owner: string; // address
@@ -41,20 +43,14 @@ export interface BattleNadStats {
   combatantBitMap: bigint; // uint64
 }
 
-export interface Weapon {
-  name: string;
-  baseDamage: bigint; // uint256
-  bonusDamage: bigint; // uint256
-  accuracy: bigint; // uint256
-  speed: bigint; // uint256
+export interface Weapon extends BaseWeapon<bigint> {
+  // All fields inherited from BaseWeapon<bigint>
+  // Contract uses bigint for all numeric values
 }
 
-export interface Armor {
-  name: string;
-  armorFactor: bigint; // uint256
-  armorQuality: bigint; // uint256
-  flexibility: bigint; // uint256
-  weight: bigint; // uint256
+export interface Armor extends BaseArmor<bigint> {
+  // All fields inherited from BaseArmor<bigint>
+  // Contract uses bigint for all numeric values
 }
 
 export interface Inventory {

--- a/src/types/domain/character.ts
+++ b/src/types/domain/character.ts
@@ -4,6 +4,7 @@
  */
 
 import { CharacterClass, StatusEffect, Ability } from './enums';
+import { BaseWeapon, BaseArmor } from '@/types/base';
 
 export interface Position {
   x: number;
@@ -34,22 +35,16 @@ export interface CharacterStats {
   unspentAttributePoints: number;
 }
 
-export interface Weapon {
+export interface Weapon extends BaseWeapon<number> {
   id: number;
-  name: string;
-  baseDamage: number;
-  bonusDamage: number;
-  accuracy: number;
-  speed: number;
+  // All other fields inherited from BaseWeapon<number>
+  // Domain uses number for all numeric values
 }
 
-export interface Armor {
+export interface Armor extends BaseArmor<number> {
   id: number;
-  name: string;
-  armorFactor: number;
-  armorQuality: number;
-  flexibility: number;
-  weight: number;
+  // All other fields inherited from BaseArmor<number>
+  // Domain uses number for all numeric values
 }
 
 export interface Inventory {


### PR DESCRIPTION
## Summary
- Fix BaseArmor interface to match actual contract field names
- Consolidate duplicate Weapon and Armor type definitions using generic base types
- Eliminate type duplication while maintaining strict type safety

This is **Part 2 of 5** for implementing issue #89 (Phase 5: Consolidate type definitions and improve type safety).

## Changes Made

### Fixed Base Types
- **BaseArmor interface**: Updated to use actual contract field names (`armorFactor`, `armorQuality`, `flexibility`, `weight`) instead of generic names
- **BaseWeapon interface**: Already matched contract fields correctly

### Contract Type Consolidation
- **`contract.Weapon`**: Now extends `BaseWeapon<bigint>`
- **`contract.Armor`**: Now extends `BaseArmor<bigint>`
- Maintains exact contract field matching with proper BigInt types

### Domain Type Consolidation  
- **`domain.Weapon`**: Now extends `BaseWeapon<number>` with additional `id` field
- **`domain.Armor`**: Now extends `BaseArmor<number>` with additional `id` field
- Uses number types for domain layer convenience

### Type Safety Benefits
- **Single source of truth**: Base interfaces define equipment structure once
- **Generic typing**: `<bigint>` for contracts, `<number>` for domain/UI
- **No duplication**: Eliminates duplicate field definitions
- **Extension flexibility**: Easy to add layer-specific fields (like `id` in domain)

## Files Modified
- `src/types/base.ts` - Fixed BaseArmor field names
- `src/types/contract/BattleNads.ts` - Contract types now extend base types
- `src/types/domain/character.ts` - Domain types now extend base types

## Test Plan
- [x] All existing tests pass (201/201) ✅
- [x] Build completes successfully ✅
- [x] Type checking passes ✅
- [x] Mappers work correctly with inheritance
- [x] No breaking changes to existing functionality

## Before/After Comparison

### Before (Duplicated)
```typescript
// Contract
export interface Weapon {
  name: string;
  baseDamage: bigint;
  bonusDamage: bigint;
  accuracy: bigint;
  speed: bigint;
}

// Domain
export interface Weapon {
  id: number;
  name: string;
  baseDamage: number;
  bonusDamage: number;
  accuracy: number;
  speed: number;
}
```

### After (Consolidated)
```typescript
// Base
export interface BaseWeapon<T = number> {
  name: string;
  baseDamage: T;
  bonusDamage: T;
  accuracy: T;
  speed: T;
}

// Contract
export interface Weapon extends BaseWeapon<bigint> {}

// Domain
export interface Weapon extends BaseWeapon<number> {
  id: number;
}
```

## Next Steps
This completes equipment type consolidation. Remaining parts:
- **Part 3**: Character types consolidation using base types
- **Part 4**: Remove unused types and standardize imports
- **Part 5**: Add explicit hook return types

🤖 Generated with [Claude Code](https://claude.ai/code)