### PR TITLE
Fix/death err

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -16,6 +16,7 @@ import { logger } from '../utils/logger';
 import { OnboardingManager } from './onboarding';
 import { useWelcomeScreen } from './onboarding/WelcomeScreen';
 import { useWallet } from '../providers/WalletProvider';
+import { safeFormatEther } from '@/utils/safeNumberConversion';
 
 const AppInitializer: React.FC = () => {
   const game = useSimplifiedGameState();
@@ -172,16 +173,10 @@ const AppInitializer: React.FC = () => {
       game.character && 
       game.character.isDead) 
   {
-    // Calculate balance lost (what the player had before death)
-    const balanceLost = game.character.inventory.balance 
-      ? `${formatEther(game.character.inventory.balance)} MON`
-      : undefined;
-
     return renderWithNav(
       <DeathModal
         isOpen={true}
         characterName={game.character.name}
-        balanceLost={balanceLost}
       />,
       "Death Modal"
     );

--- a/src/components/game/modals/DeathModal.tsx
+++ b/src/components/game/modals/DeathModal.tsx
@@ -17,7 +17,7 @@ interface DeathModalProps {
   isOpen: boolean;
   onClose?: () => void; // Optional since death modal might not be dismissible
   characterName?: string;
-  balanceLost?: string; // Formatted balance string
+  balanceLost?: string; // Optional - not currently displayed but kept for future use
 }
 
 const DeathModal: React.FC<DeathModalProps> = ({ 

--- a/src/hooks/wallet/useWalletState.ts
+++ b/src/hooks/wallet/useWalletState.ts
@@ -10,6 +10,7 @@ import {
   DIRECT_FUNDING_AMOUNT,
   MIN_SAFE_OWNER_BALANCE 
 } from '@/config/wallet';
+import { safeFormatEther, safeFormatUnits } from '@/utils/safeNumberConversion';
 
 export interface WalletBalanceData {
   // Balance values (formatted strings)
@@ -136,19 +137,19 @@ export function useWalletState(options: UseWalletStateOptions = {}): WalletBalan
 
   // Format balance values
   const sessionKeyBalance = useMemo(() => {
-    return hasValidSessionKeyData ? ethers.formatUnits(sessionKeyBalanceBigInt, 18) : '0';
+    return hasValidSessionKeyData ? safeFormatUnits(sessionKeyBalanceBigInt, 18) : '0';
   }, [hasValidSessionKeyData, sessionKeyBalanceBigInt]);
 
   const bondedBalance = useMemo(() => {
-    return hasValidSessionKeyData ? ethers.formatUnits(bondedBalanceBigInt, 18) : '0';
+    return hasValidSessionKeyData ? safeFormatUnits(bondedBalanceBigInt, 18) : '0';
   }, [hasValidSessionKeyData, bondedBalanceBigInt]);
 
   const targetBalance = useMemo(() => {
-    return hasValidSessionKeyData ? ethers.formatUnits(targetBalanceBigInt, 18) : '0';
+    return hasValidSessionKeyData ? safeFormatUnits(targetBalanceBigInt, 18) : '0';
   }, [hasValidSessionKeyData, targetBalanceBigInt]);
 
   const formattedShortfall = useMemo(() => {
-    return hasValidSessionKeyData && shortfall > 0 ? ethers.formatEther(shortfall) : '0';
+    return hasValidSessionKeyData && shortfall > 0 ? safeFormatEther(shortfall) : '0';
   }, [hasValidSessionKeyData, shortfall]);
 
   // Transaction validation (if enabled)

--- a/src/utils/safeNumberConversion.ts
+++ b/src/utils/safeNumberConversion.ts
@@ -1,0 +1,177 @@
+/**
+ * Safe number conversion utilities to prevent overflow errors
+ * Handles large BigInt values that exceed JavaScript's safe integer range
+ */
+
+import { ethers } from 'ethers';
+
+// JavaScript's safe integer range
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+// Maximum reasonable wei value (1 billion ETH)
+const MAX_REASONABLE_WEI = BigInt('1000000000000000000000000000');
+
+/**
+ * Safely converts a BigInt to number with overflow protection
+ * @param value - BigInt value to convert
+ * @param fallback - Fallback value if conversion fails
+ * @returns Safe number or fallback
+ */
+export function safeToNumber(value: bigint | number | null | undefined, fallback: number = 0): number {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === 'number') {
+    return isFinite(value) ? value : fallback;
+  }
+
+  try {
+    const bigintValue = BigInt(value);
+    
+    if (bigintValue > MAX_SAFE_BIGINT || bigintValue < MIN_SAFE_BIGINT) {
+      console.warn(`BigInt value ${bigintValue} exceeds safe integer range, using fallback`);
+      return fallback;
+    }
+    
+    return Number(bigintValue);
+  } catch (error) {
+    console.error('Error converting to number:', error, 'Value:', value);
+    return fallback;
+  }
+}
+
+/**
+ * Safely formats a value as Ether with overflow protection
+ * @param value - Value to format (BigInt, string, or number)
+ * @param fallback - Fallback string if conversion fails
+ * @returns Formatted Ether string or fallback
+ */
+export function safeFormatEther(value: bigint | string | number | null | undefined, fallback: string = '0'): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  try {
+    let bigintValue: bigint;
+    
+    if (typeof value === 'string') {
+      bigintValue = BigInt(value);
+    } else if (typeof value === 'number') {
+      if (!isFinite(value) || value < 0) {
+        console.warn(`Invalid number value: ${value}`);
+        return fallback;
+      }
+      bigintValue = BigInt(Math.floor(value));
+    } else {
+      bigintValue = value;
+    }
+    
+    // Check for extremely large values that might indicate corrupted data
+    if (bigintValue > MAX_REASONABLE_WEI) {
+      console.warn(`Value ${bigintValue} is extremely large, may be corrupted data`);
+      return 'Value too large to display';
+    }
+
+    // Check for negative values
+    if (bigintValue < 0) {
+      console.warn(`Negative value ${bigintValue} cannot be formatted as Ether`);
+      return fallback;
+    }
+
+    return ethers.formatEther(bigintValue);
+  } catch (error) {
+    console.error('Error formatting Ether value:', error, 'Value:', value);
+    return fallback;
+  }
+}
+
+/**
+ * Safely formats a value with specified units and overflow protection
+ * @param value - Value to format (BigInt, string, or number)
+ * @param units - Number of decimal places or unit name
+ * @param fallback - Fallback string if conversion fails
+ * @returns Formatted string or fallback
+ */
+export function safeFormatUnits(
+  value: bigint | string | number | null | undefined, 
+  units: string | number = 18, 
+  fallback: string = '0'
+): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  try {
+    let bigintValue: bigint;
+    
+    if (typeof value === 'string') {
+      bigintValue = BigInt(value);
+    } else if (typeof value === 'number') {
+      if (!isFinite(value) || value < 0) {
+        console.warn(`Invalid number value: ${value}`);
+        return fallback;
+      }
+      bigintValue = BigInt(Math.floor(value));
+    } else {
+      bigintValue = value;
+    }
+    
+    // Check for extremely large values
+    if (bigintValue > MAX_REASONABLE_WEI) {
+      console.warn(`Value ${bigintValue} is extremely large, may be corrupted data`);
+      return 'Value too large to display';
+    }
+
+    // Check for negative values
+    if (bigintValue < 0) {
+      console.warn(`Negative value ${bigintValue} cannot be formatted`);
+      return fallback;
+    }
+
+    return ethers.formatUnits(bigintValue, units);
+  } catch (error) {
+    console.error('Error formatting units value:', error, 'Value:', value, 'Units:', units);
+    return fallback;
+  }
+}
+
+/**
+ * Safely parses a value to BigInt with validation
+ * @param value - Value to parse
+ * @param fallback - Fallback BigInt if parsing fails
+ * @returns Parsed BigInt or fallback
+ */
+export function safeToBigInt(value: any, fallback: bigint = BigInt(0)): bigint {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  try {
+    if (typeof value === 'bigint') {
+      return value;
+    }
+    
+    if (typeof value === 'string') {
+      // Handle empty strings
+      if (value.trim() === '') {
+        return fallback;
+      }
+      return BigInt(value);
+    }
+    
+    if (typeof value === 'number') {
+      if (!isFinite(value)) {
+        return fallback;
+      }
+      return BigInt(Math.floor(value));
+    }
+    
+    // Try to convert other types to string first
+    return BigInt(String(value));
+  } catch (error) {
+    console.error('Error converting to BigInt:', error, 'Value:', value);
+    return fallback;
+  }
+} 


### PR DESCRIPTION
# Fix: Remove unused balance calculation causing overflow error

## Problem
Users with dead characters experienced complete application crashes due to `TypeError: overflow` when `formatEther` tried to process corrupted character data (`75128168340049070`).

## Root Cause
- **Location**: `AppInitializer.tsx:177` 
- **Issue**: `formatEther(game.character.inventory.balance)` called on corrupted dead character data
- **Impact**: App crash prevented character recovery

## Solution
**Primary Fix**: Removed the unused `balanceLost` calculation from the death modal flow since:
- Balance is never displayed to users (commented out in `DeathModal.tsx`)
- Death modal only shows: "YOU DIED", character name, and "Create New Character" button

**Preventive Fix**: Added safe conversion utilities and applied them to `useWalletState.ts` to prevent similar overflow errors in balance formatting operations throughout the app.

## Changes
- ✅ `AppInitializer.tsx` - Removed problematic balance calculation
- ✅ `DeathModal.tsx` - Updated prop documentation
- ✅ `safeNumberConversion.ts` - NEW: Safe conversion utilities with overflow protection
- ✅ `useWalletState.ts` - Applied `safeFormatEther`/`safeFormatUnits` to all balance formatting

## Testing
- [x] Death modal displays correctly without balance
- [x] Users can create new characters after death
- [ ] Test with previously problematic wallet

## Impact
- **Before**: Complete app crash for affected users
- **After**: Clean death modal → character creation flow 