### PR TITLE
Fix: Update types for new CombatTracker struct in ABI

### DIFF
--- a/src/hooks/game/__tests__/useContractPolling.test.tsx
+++ b/src/hooks/game/__tests__/useContractPolling.test.tsx
@@ -41,8 +41,8 @@ describe('useContractPolling', () => {
 
   const mockSnapshotData = [
     'char1', // characterID
-    { key: '0xsessionkey', expiration: 1000n }, // sessionKeyData
-    { id: 'char1', name: 'TestChar' }, // character
+    { key: '0xsessionkey', expiration: BigInt(1000) }, // sessionKeyData
+    { id: 'char1', name: 'TestChar', stats: { unspentAttributePoints: 5 }, activeTask: { taskAddress: '0x0' } }, // character
     [], // combatants
     [], // noncombatants
     [], // equipableWeaponIDs
@@ -50,9 +50,8 @@ describe('useContractPolling', () => {
     [], // equipableArmorIDs
     [], // equipableArmorNames
     [], // dataFeeds
-    0n, // balanceShortfall
-    5, // unallocatedAttributePoints
-    500n, // endBlock
+    BigInt(0), // balanceShortfall
+    BigInt(500), // endBlock
   ];
 
   const mockClient = {
@@ -101,8 +100,8 @@ describe('useContractPolling', () => {
     expect(mockClient.getUiSnapshot).toHaveBeenCalledWith(mockOwner, expect.any(BigInt));
     expect(result.current.data).toEqual({
       characterID: 'char1',
-      sessionKeyData: { key: '0xsessionkey', expiration: 1000n },
-      character: { id: 'char1', name: 'TestChar' },
+      sessionKeyData: { key: '0xsessionkey', expiration: BigInt(1000) },
+      character: { id: 'char1', name: 'TestChar', stats: { unspentAttributePoints: 5 }, activeTask: { taskAddress: '0x0' } },
       combatants: [],
       noncombatants: [],
       equipableWeaponIDs: [],
@@ -110,9 +109,8 @@ describe('useContractPolling', () => {
       equipableArmorIDs: [],
       equipableArmorNames: [],
       dataFeeds: [],
-      balanceShortfall: 0n,
-      unallocatedAttributePoints: 5,
-      endBlock: 500n,
+      balanceShortfall: BigInt(0),
+      endBlock: BigInt(500),
       fetchTimestamp: expect.any(Number),
     });
   });

--- a/src/hooks/game/useContractPolling.ts
+++ b/src/hooks/game/useContractPolling.ts
@@ -30,7 +30,7 @@ export const useContractPolling = (owner: string | null) => {
       const rawArrayData = await client.getUiSnapshot(owner, startBlock);
       const fetchTimestamp = Date.now();
       
-      if (!rawArrayData || typeof (rawArrayData as any)[0] === 'undefined' || typeof (rawArrayData as any)[12] === 'undefined') {
+      if (!rawArrayData || typeof (rawArrayData as any)[0] === 'undefined' || typeof (rawArrayData as any)[11] === 'undefined') {
         throw new Error("Invalid data structure received from getUiSnapshot");
       }
       
@@ -47,8 +47,7 @@ export const useContractPolling = (owner: string | null) => {
         equipableArmorNames: dataAsAny[8],
         dataFeeds: dataAsAny[9] || [],
         balanceShortfall: dataAsAny[10],
-        unallocatedAttributePoints: dataAsAny[11],
-        endBlock: dataAsAny[12],
+        endBlock: dataAsAny[11],
         fetchTimestamp: fetchTimestamp,
       };
     },

--- a/src/mappers/contractToDomain.ts
+++ b/src/mappers/contractToDomain.ts
@@ -846,16 +846,18 @@ export function contractToWorldSnapshot(
   const mappedSessionKeyData = mapSessionKeyData(raw.sessionKeyData, owner);
 
   // Create the domain world snapshot (Now includes eventLogs and chatLogs)
+  const mappedCharacter = mapCharacter(raw.character);
+  
   const partialWorldSnapshot: domain.WorldSnapshot = {
     characterID: raw.characterID || '',
     sessionKeyData: mappedSessionKeyData,
-    character: mapCharacter(raw.character),
+    character: mappedCharacter,
     combatants: (raw.combatants || []).map(mapCharacterLite),
     noncombatants: (raw.noncombatants || []).map(mapCharacterLite),
     eventLogs: allEventLogs,
     chatLogs: allChatMessages,
     balanceShortfall: raw.balanceShortfall || BigInt(0),
-    unallocatedAttributePoints: character?.stats.unspentAttributePoints || 0,
+    unallocatedAttributePoints: mappedCharacter?.stats.unspentAttributePoints || 0,
     lastBlock: Number(raw.endBlock || 0)
   };
 

--- a/src/mappers/contractToDomain.ts
+++ b/src/mappers/contractToDomain.ts
@@ -304,7 +304,7 @@ export function mapCharacter(
     },
     areaId,
     owner: rawCharacter.owner,
-    activeTask: rawCharacter.activeTask,
+    activeTask: rawCharacter.activeTask.taskAddress,
     ability: {
       ability: rawCharacter.activeAbility.ability as domain.Ability,
       stage: rawCharacter.activeAbility.stage,
@@ -855,7 +855,7 @@ export function contractToWorldSnapshot(
     eventLogs: allEventLogs,
     chatLogs: allChatMessages,
     balanceShortfall: raw.balanceShortfall || BigInt(0),
-    unallocatedAttributePoints: Number(raw.unallocatedAttributePoints || 0),
+    unallocatedAttributePoints: character?.stats.unspentAttributePoints || 0,
     lastBlock: Number(raw.endBlock || 0)
   };
 

--- a/src/types/contract/BattleNads.ts
+++ b/src/types/contract/BattleNads.ts
@@ -59,6 +59,16 @@ export interface Inventory {
   balance: bigint; // uint128
 }
 
+// Combat tracker structure (Matches CombatTracker struct)
+export interface CombatTracker {
+  hasTaskError: boolean;
+  pending: boolean;
+  taskDelay: number; // uint8
+  executorDelay: number; // uint8
+  taskAddress: string; // address
+  targetBlock: bigint; // uint64
+}
+
 // Ability state structure (Matches AbilityTracker struct)
 export interface AbilityState {
   ability: number; // uint8 (enum Ability)
@@ -88,7 +98,7 @@ export interface Character {
   maxHealth: bigint; // uint256
   weapon: Weapon;
   armor: Armor;
-  activeTask: string; // address
+  activeTask: CombatTracker;
   activeAbility: AbilityState;
   inventory: Inventory;
   tracker: StorageTracker; // Not directly used by frontend polling, but part of struct
@@ -152,7 +162,6 @@ export interface PollFrontendDataReturn {
   equipableArmorNames: string[];
   dataFeeds: DataFeed[]; // Array of per-block data feeds
   balanceShortfall: bigint; // uint256
-  unallocatedAttributePoints: bigint; // uint256 - NOTE: Contract seems to return uint256 here
   endBlock: bigint; // uint256
   fetchTimestamp: number; // Timestamp (ms since epoch) when this data was fetched
 } 


### PR DESCRIPTION
## Description

Updates frontend to handle the new ABI changes from the smart contract refactor.

## Changes

### 1. Updated Contract Types
- Added  interface to handle the new struct that replaces the simple  address
- Updated  interface to use  instead of string for 
- Removed  from  as it's no longer returned by 

### 2. Fixed Data Mapping
- Updated polling implementation to handle the removed  field
- Fixed array indices in  after field removal
- Updated  mapper to extract  from the new  struct
- Changed  mapping to use  instead

### 3. Updated Tests
- Fixed  test to match the new data structure
- Removed expectations for  in polling data
- Added proper structure for character with stats and activeTask

## Test Plan

1. Build passes: ✅ 
> battle-nads@0.2.0 build
> next build

  ▲ Next.js 14.2.28
  - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/9) ...
   Generating static pages (2/9) 
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
   Generating static pages (4/9) 
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}
   Generating static pages (6/9) 
 ✓ Generating static pages (9/9)
   Finalizing page optimization ...
   Collecting build traces ...
[PrivyAuthProvider] Initialized with config: {"appId":"cm8y33v8l01t992f8gkt1zt09","noPromptOnSignature":true,"noPromptOnTransaction":true}

Route (app)                              Size     First Load JS
┌ ○ /                                    41.4 kB        1.12 MB
├ ○ /_not-found                          880 B          89.9 kB
├ ○ /character                           4.44 kB        1.04 MB
├ ○ /create                              5.77 kB        1.03 MB
├ ○ /dashboard                           722 B          1.01 MB
└ ○ /game                                1.13 kB        1.08 MB
+ First Load JS shared by all            89.1 kB
  ├ chunks/2117-213dfa29e93d1b90.js      31.9 kB
  ├ chunks/fd9d1056-d576a4f5779ec0ca.js  53.6 kB
  └ other shared chunks (total)          3.56 kB


○  (Static)  prerendered as static content
2. Tests pass: ✅ 
> battle-nads@0.2.0 test
> jest
3. Character info should display correctly with unspent attribute points from stats
4. Active tasks should still work (accessing )

## Notes

The new  struct provides additional information about task execution:
- : Whether the task encountered an error
- : Whether the task is pending execution
-  and : Timing information
- : When the task will execute

This additional data could be used in the future to show better task execution status in the UI.

by-claude