### PR TITLE
Test: Update pollFrontendData.json fixture for new ABI structure

### DIFF
--- a/src/mappers/__tests__/__fixtures__/pollFrontendData.json
+++ b/src/mappers/__tests__/__fixtures__/pollFrontendData.json
@@ -56,7 +56,14 @@
       "armorBitmap": "6",
       "balance": "500000000000000000"
     },
-    "activeTask": "0x0000000000000000000000000000000000000000",
+    "activeTask": {
+      "hasTaskError": false,
+      "pending": false,
+      "taskDelay": 0,
+      "executorDelay": 0,
+      "taskAddress": "0x0000000000000000000000000000000000000000",
+      "targetBlock": "0"
+    },
     "activeAbility": {
       "ability": 0,
       "stage": 0,
@@ -116,6 +123,5 @@
     }
   ],
   "balanceShortfall": "0",
-  "unallocatedAttributePoints": "3",
   "endBlock": 150
 } 


### PR DESCRIPTION
## Description

This PR updates the test fixture to match the new ABI structure introduced in the smart contract refactor. This completes the remaining tasks from issue #146.

## Changes

### Updated Test Fixture
- **activeTask**: Changed from string to CombatTracker object with all required fields:
  - `hasTaskError`: false
  - `pending`: false
  - `taskDelay`: 0
  - `executorDelay`: 0
  - `taskAddress`: "0x0000..." (the original address value)
  - `targetBlock`: "0"
- **Removed unallocatedAttributePoints**: This field is no longer included in the polling data

## Test Results

All tests pass with the updated fixture:
- ✅ 32 test suites passed
- ✅ 340 tests passed
- ✅ No failing tests

## Related Issues

Closes remaining tasks from #146

by-claude