### PR TITLE
79 fix/stat-allocation-ui

### DIFF
--- a/src/components/characters/CharacterCard.tsx
+++ b/src/components/characters/CharacterCard.tsx
@@ -432,7 +432,7 @@ const StatAllocationPanel: React.FC<{
           {unspentAttributePoints - pointsUsed}
         </Badge>
       </Flex>
-{/*       
+      
       <Button 
         colorScheme="blue" 
         size="sm" 
@@ -443,7 +443,7 @@ const StatAllocationPanel: React.FC<{
         mt={2}
       >
         Confirm Allocation
-      </Button> */}
+      </Button>
     </VStack>
   );
 }; 

--- a/src/components/characters/CharacterCard.tsx
+++ b/src/components/characters/CharacterCard.tsx
@@ -432,7 +432,7 @@ const StatAllocationPanel: React.FC<{
           {unspentAttributePoints - pointsUsed}
         </Badge>
       </Flex>
-      
+{/*       
       <Button 
         colorScheme="blue" 
         size="sm" 
@@ -443,7 +443,7 @@ const StatAllocationPanel: React.FC<{
         mt={2}
       >
         Confirm Allocation
-      </Button>
+      </Button> */}
     </VStack>
   );
 }; 

--- a/src/components/game/board/StatDisplay.tsx
+++ b/src/components/game/board/StatDisplay.tsx
@@ -114,7 +114,7 @@ export const StatDisplay = memo<StatDisplayProps>(({ stats, unallocatedAttribute
 
   return (
     <VStack spacing={3}>
-      <div className="grid grid-cols-2 gap-2 text-xl w-full">
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-2 text-xl w-full">
         <StatRow 
           label="STR" 
           value={Number(stats?.strength)} 


### PR DESCRIPTION
Fix issue: [UI:Bug Point allocation screen on smaller resolution #156](https://github.com/FastLane-Labs/battle-nads-frontend/issues/156)

Addressed this by reducing the overall horizontal real-state/ size of the "allocate attribute point" component on smaller screens

<img width="417" alt="Screenshot 2025-07-04 at 12 03 48 AM" src="https://github.com/user-attachments/assets/dc1dc91c-bbf7-4ca9-b443-9aa2abb46c4a" />
