### PR TITLE
Fix: Ensure read provider uses dedicated RPC for polling

### DIFF
--- a/src/hooks/contracts/__tests__/useBattleNadsClient.test.ts
+++ b/src/hooks/contracts/__tests__/useBattleNadsClient.test.ts
@@ -92,8 +92,8 @@ describe('useBattleNadsClient', () => {
     expect(result.current.client).not.toBeNull();
     expect(result.current.error).toBeNull();
     
-    // Should have created 2 adapters (1 for websocket fallback, 1 for read) 
-    expect(BattleNadsAdapter).toHaveBeenCalledTimes(2);
+    // Should have created only 1 adapter (read) when WebSocket is disabled
+    expect(BattleNadsAdapter).toHaveBeenCalledTimes(1);
     
     // Check that client was created with only read adapter
     expect(BattleNadsClient).toHaveBeenCalledWith({
@@ -148,8 +148,10 @@ describe('useBattleNadsClient', () => {
 
     const { result } = renderHook(() => useBattleNadsClient());
 
-    // Assertions - includes WebSocket fallback providers and read providers
-    expect(JsonRpcProvider).toHaveBeenCalledTimes(4); // WebSocket fallback + read provider creation
+    // Should have called JsonRpcProvider twice:
+    // 1. First call in readProvider useMemo throws error
+    // 2. Second call in catch block succeeds
+    expect(JsonRpcProvider).toHaveBeenCalledTimes(2);
     expect(result.current.error).toMatch(/Provider creation failed/);
     // Check client is not null because fallback provider succeeded
     expect(result.current.client).not.toBeNull(); 

--- a/src/hooks/contracts/useBattleNadsClient.ts
+++ b/src/hooks/contracts/useBattleNadsClient.ts
@@ -18,8 +18,7 @@ export const useBattleNadsClient = () => {
   // Initialize WebSocket provider manager (if enabled)
   useEffect(() => {
     if (!ENABLE_WEBSOCKET) {
-      // WebSocket disabled, use HTTP directly
-      setWsProvider(new JsonRpcProvider(RPC_URLS.PRIMARY_HTTP));
+      // WebSocket disabled, no need to set state - we'll create HTTP provider directly in useMemo
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fixed an issue where the read provider was incorrectly using wallet providers for polling
- Ensures dedicated RPC endpoint is always used for read operations when WebSocket is disabled

## Problem
When WebSocket was disabled, the `readProvider` in `useBattleNadsClient` would fall back to using wallet providers (injected or embedded) instead of the dedicated HTTP RPC endpoint. This caused polling requests to go through the user's wallet provider (like MetaMask), leading to:
- Rate limiting issues from wallet provider RPCs
- Inconsistent polling behavior
- Potential reliability issues

## Solution
Modified the `readProvider` logic to:
1. Use WebSocket provider when enabled and available
2. Always use dedicated HTTP RPC endpoint when WebSocket is disabled
3. Never fall back to wallet providers for polling operations

## Test Plan
1. Set `NEXT_PUBLIC_ENABLE_WEBSOCKET=false` in `.env.local`
2. Connect wallet and enter game
3. Verify polling continues working without rate limit errors
4. Check network tab to confirm requests go to the configured RPC endpoint
5. Test with `NEXT_PUBLIC_ENABLE_WEBSOCKET=true` to ensure WebSocket still works

by-claude