### PR TITLE
feat: implement combat task status bar with countdown timer and error handling

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -90,6 +90,7 @@ export default function GameV2Page() {
             isInCombat={game.isInCombat || false}
             isCacheLoading={game.isCacheLoading || false}
             fogOfWar={game.fogOfWar}
+            rawEndBlock={game.rawEndBlock}
           />
         </Box>
       </>

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -286,6 +286,7 @@ const AppInitializer: React.FC = () => {
            equipableArmorIDs={rawEquipableArmorIDs}
            equipableArmorNames={rawEquipableArmorNames}
            fogOfWar={game.fogOfWar}
+           rawEndBlock={game.rawEndBlock}
          />,
          "Game Container"
       );

--- a/src/components/game/GameContainer.tsx
+++ b/src/components/game/GameContainer.tsx
@@ -43,6 +43,8 @@ interface GameContainerProps {
   equipableArmorNames?: string[];
   // Add fog-of-war data
   fogOfWar?: hooks.UseGameDataReturn['fogOfWar'];
+  // Add raw end block from polling data for combat task status
+  rawEndBlock?: bigint;
 }
 
 const GameContainer: React.FC<GameContainerProps> = (props) => {
@@ -64,8 +66,12 @@ const GameContainer: React.FC<GameContainerProps> = (props) => {
     equipableWeaponNames,
     equipableArmorIDs,
     equipableArmorNames,
-    fogOfWar
+    fogOfWar,
+    rawEndBlock
   } = props;
+
+  // Calculate current block from polling data
+  const currentBlock = Number(rawEndBlock || 0);
 
   const isSpawned = !(position.x === 0 && position.y === 0 && position.z === 0);
 
@@ -223,6 +229,7 @@ const GameContainer: React.FC<GameContainerProps> = (props) => {
           equipableArmorIDs={equipableArmorIDs}
           equipableArmorNames={equipableArmorNames}
           fogOfWar={fogOfWar}
+          currentBlock={currentBlock}
         />
       </Flex>
     </Box>

--- a/src/components/game/controls/CombatTargets.tsx
+++ b/src/components/game/controls/CombatTargets.tsx
@@ -3,6 +3,7 @@ import { Box, Button, VStack, Text, Flex } from '@chakra-ui/react';
 import { domain } from '../../../types';
 import HealthBar from '../ui/HealthBar';
 import { calculateThreatLevel, getThreatColors } from '@/utils/threatLevel';
+import { CombatTaskStatusBar } from './CombatTaskStatusBar';
 
 interface CombatTargetsProps {
   combatants: domain.CharacterLite[];
@@ -11,6 +12,9 @@ interface CombatTargetsProps {
   onSelectTarget: (index: number | null) => void;
   currentPlayerId?: string; // Add current player ID to filter them out
   currentPlayerLevel?: number; // Add current player level for threat calculation
+  activeTask?: domain.CombatTracker; // Add active task for combat task status
+  currentBlock?: number; // Add current block for task countdown
+  isInCombat?: boolean; // Add combat state for task bar persistence
 }
 
 const CombatTargets: React.FC<CombatTargetsProps> = ({ 
@@ -19,7 +23,10 @@ const CombatTargets: React.FC<CombatTargetsProps> = ({
   selectedTargetIndex,
   onSelectTarget,
   currentPlayerId,
-  currentPlayerLevel
+  currentPlayerLevel,
+  activeTask,
+  currentBlock,
+  isInCombat
 }) => {
   // Helper function to check if a character class is a player class
   const isPlayerClass = (classValue: domain.CharacterClass): boolean => {
@@ -209,6 +216,15 @@ const CombatTargets: React.FC<CombatTargetsProps> = ({
   return (
     <Box h="100%" display="flex" flexDirection="column">
       <h2 className='uppercase gold-text-light text-2xl font-bold tracking-tight mb-2 text-center'>Combat</h2>
+      
+      {/* Combat Task Status Bar */}
+      {activeTask && currentBlock !== undefined && (
+        <CombatTaskStatusBar 
+          activeTask={activeTask}
+          currentBlock={currentBlock}
+          isInCombat={isInCombat}
+        />
+      )}
       
       {validCombatants.length === 0 && playerNoncombatants.length === 0 && enemyNoncombatants.length === 0 ? (
         <Box className="flex items-center justify-center h-full w-full bg-dark-brown rounded-md">

--- a/src/components/game/controls/CombatTaskStatusBar.tsx
+++ b/src/components/game/controls/CombatTaskStatusBar.tsx
@@ -1,0 +1,169 @@
+import React, { useMemo } from 'react';
+import { Box, Flex, Progress, Text, Badge } from '@chakra-ui/react';
+import { domain } from '@/types';
+import { AVG_BLOCK_TIME_MS } from '@/config/gas';
+
+interface CombatTaskStatusBarProps {
+  activeTask: domain.CombatTracker;
+  currentBlock: number;
+  isInCombat?: boolean; // Add combat state to help determine visibility
+}
+
+export const CombatTaskStatusBar: React.FC<CombatTaskStatusBarProps> = ({
+  activeTask,
+  currentBlock,
+  isInCombat = false,
+}) => {
+  // Check if there's an active task to display
+  const hasActiveTask = useMemo(() => {
+    return activeTask.pending || 
+           activeTask.hasTaskError || 
+           (activeTask.targetBlock > 0 && currentBlock < activeTask.targetBlock);
+  }, [activeTask, currentBlock]);
+
+  // Show the bar if in combat OR if there's an active task
+  // This prevents flickering when task data updates during combat
+  const shouldShowBar = useMemo(() => {
+    return isInCombat || hasActiveTask;
+  }, [isInCombat, hasActiveTask]);
+
+  // Calculate countdown information
+  const countdownInfo = useMemo(() => {
+    if (activeTask.targetBlock <= 0) {
+      return { blocksRemaining: 0, timeRemaining: 0, progress: 0 };
+    }
+
+    const blocksRemaining = Math.max(0, activeTask.targetBlock - currentBlock);
+    const timeRemaining = blocksRemaining * (AVG_BLOCK_TIME_MS / 1000);
+    
+    // Progress bar shows remaining time (decreases as time passes)
+    // Use a simple approach: show remaining blocks as percentage of typical task duration (5 blocks)
+    const estimatedTaskDuration = 5;
+    const progress = Math.min(100, Math.max(0, (blocksRemaining / estimatedTaskDuration) * 100));
+
+    return { blocksRemaining, timeRemaining, progress };
+  }, [activeTask.targetBlock, currentBlock]);
+
+  // Determine task status and styling
+  const taskStatus = useMemo(() => {
+    if (activeTask.hasTaskError) {
+      return {
+        label: 'ERROR',
+        color: '#FF4444', // Red
+        bgColor: 'red.900',
+        borderColor: 'red.500',
+      };
+    }
+    
+    if (activeTask.pending) {
+      return {
+        label: 'PENDING',
+        color: '#FFA500', // Orange
+        bgColor: 'orange.900',
+        borderColor: 'orange.500',
+      };
+    }
+    
+    if (countdownInfo.blocksRemaining > 0) {
+      return {
+        label: 'EXECUTING',
+        color: '#4169E1', // Royal Blue
+        bgColor: 'blue.900',
+        borderColor: 'blue.500',
+      };
+    }
+    
+    return {
+      label: 'READY',
+      color: '#32CD32', // Lime Green
+      bgColor: 'green.900',
+      borderColor: 'green.500',
+    };
+  }, [activeTask.hasTaskError, activeTask.pending, countdownInfo.blocksRemaining]);
+
+  // Don't render if not in combat and no active task
+  if (!shouldShowBar) {
+    return null;
+  }
+
+  // If in combat but no active task, show a "Ready" state
+  const displayStatus = hasActiveTask ? taskStatus : {
+    label: 'READY',
+    color: '#32CD32', // Lime Green
+    bgColor: 'green.900',
+    borderColor: 'green.500',
+  };
+
+  return (
+    <Box 
+      p={2}
+      borderRadius="md"
+      mb={2}
+      className="bg-dark-brown"
+      borderColor={displayStatus.borderColor}
+      borderWidth="1px"
+    >
+      <Flex align="center" gap={2} fontSize="sm">
+        {/* Task Status Badge */}
+        <Badge 
+          px={1.5} 
+          py={0.5} 
+          borderRadius="sm" 
+          bg={displayStatus.color}
+          color="black"
+          opacity={0.9}
+          fontSize="xs"
+        >
+          <Text className="font-bold uppercase">{displayStatus.label}</Text>
+        </Badge>
+
+        {/* Progress Bar (only show for executing tasks with active task) */}
+        {hasActiveTask && countdownInfo.blocksRemaining > 0 && !activeTask.hasTaskError && (
+          <Box flex="1" px={2}>
+            <Progress 
+              value={countdownInfo.progress} 
+              size="sm" 
+              borderRadius="sm"
+              bg="blackAlpha.400"
+              sx={{
+                '& > div': {
+                  backgroundColor: displayStatus.color,
+                }
+              }}
+            />
+          </Box>
+        )}
+
+        {/* Countdown Timer (only show for executing tasks with active task) */}
+        {hasActiveTask && countdownInfo.blocksRemaining > 0 && !activeTask.hasTaskError && (
+          <Text className="text-white font-medium" minWidth="40px" textAlign="right" fontSize="xs">
+            {countdownInfo.timeRemaining.toFixed(1)}s
+          </Text>
+        )}
+
+        {/* Task Delays Display (only show when there's an active task) */}
+        {hasActiveTask && (activeTask.taskDelay > 0 || activeTask.executorDelay > 0) && (
+          <Flex gap={1}>
+            {activeTask.taskDelay > 0 && (
+              <Badge colorScheme="yellow" variant="outline" fontSize="xs">
+                +{activeTask.taskDelay}
+              </Badge>
+            )}
+            {activeTask.executorDelay > 0 && (
+              <Badge colorScheme="yellow" variant="outline" fontSize="xs">
+                +{activeTask.executorDelay}
+              </Badge>
+            )}
+          </Flex>
+        )}
+
+        {/* Error Message (only show when there's an active task with error) */}
+        {hasActiveTask && activeTask.hasTaskError && (
+          <Text className="text-red-300 font-medium" flex="1" fontSize="xs">
+            Attack to restart combat
+          </Text>
+        )}
+      </Flex>
+    </Box>
+  );
+}; 

--- a/src/components/game/layout/GameView.tsx
+++ b/src/components/game/layout/GameView.tsx
@@ -28,6 +28,7 @@ interface GameViewProps {
   equipableArmorIDs?: number[];
   equipableArmorNames?: string[];
   fogOfWar?: hooks.UseGameDataReturn['fogOfWar'];
+  currentBlock?: number; // Add current block for combat task status
 }
 
 const GameView: React.FC<GameViewProps> = ({
@@ -49,7 +50,8 @@ const GameView: React.FC<GameViewProps> = ({
   equipableWeaponNames,
   equipableArmorIDs,
   equipableArmorNames,
-  fogOfWar
+  fogOfWar,
+  currentBlock
 }) => {
   const [selectedTargetIndex, setSelectedTargetIndex] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<'character' | 'actions' | 'map'>('character');
@@ -136,6 +138,9 @@ const GameView: React.FC<GameViewProps> = ({
               onSelectTarget={handleSelectTarget}
               currentPlayerId={character.id}
               currentPlayerLevel={character.level}
+              activeTask={character.activeTask}
+              currentBlock={currentBlock}
+              isInCombat={isInCombat}
             />
             
           </Box>

--- a/src/utils/log-builder.ts
+++ b/src/utils/log-builder.ts
@@ -250,8 +250,8 @@ export function enrichLog(raw: LogEntryRaw, playerIndex?: number | null, playerW
       const isPlayerAttacker = raw.attacker?.name === "You" || 
                               (playerCharacterName && raw.attacker?.name === playerCharacterName) ||
                               (playerCharacterName && isSamePlayer(raw.attacker?.name || '', playerCharacterName));
-      const isCurrentArea = currentAreaId === undefined || raw.areaId === currentAreaId;
-      const isActorPlayer = isPlayerAttacker && isCurrentArea;
+      // For area movement events, don't check isCurrentArea - always show "You" for the player
+      const isActorPlayer = isPlayerAttacker;
       const actorName = formatActorName(actor, isActorPlayer || false, false);
       
       return {
@@ -269,8 +269,8 @@ export function enrichLog(raw: LogEntryRaw, playerIndex?: number | null, playerW
       const isPlayerAttacker = raw.attacker?.name === "You" || 
                               (playerCharacterName && raw.attacker?.name === playerCharacterName) ||
                               (playerCharacterName && isSamePlayer(raw.attacker?.name || '', playerCharacterName));
-      const isCurrentArea = currentAreaId === undefined || raw.areaId === currentAreaId;
-      const isActorPlayer = isPlayerAttacker && isCurrentArea;
+      // For area movement events, don't check isCurrentArea - always show "You" for the player
+      const isActorPlayer = isPlayerAttacker;
       const actorName = formatActorName(actor, isActorPlayer || false, false);
       
       return {
@@ -312,8 +312,8 @@ export function enrichLog(raw: LogEntryRaw, playerIndex?: number | null, playerW
       const isPlayerAttacker = raw.attacker?.name === "You" || 
                               (playerCharacterName && raw.attacker?.name === playerCharacterName) ||
                               (playerCharacterName && isSamePlayer(raw.attacker?.name || '', playerCharacterName));
-      const isCurrentArea = currentAreaId === undefined || raw.areaId === currentAreaId;
-      const isActorPlayer = isPlayerAttacker && isCurrentArea;
+      // For level up events, don't check isCurrentArea - always show "You" for the player
+      const isActorPlayer = isPlayerAttacker;
       const actorName = formatActorName(actor, isActorPlayer || false, false);
       const experience = raw.details.experience || 0;
       


### PR DESCRIPTION
## feat: add combat task status bar with countdown timer
<img width="534" alt="Screenshot 2025-07-04 at 2 27 05 pm" src="https://github.com/user-attachments/assets/26786f85-6fdc-482d-94ec-39b5d1a1c372" />


Fixes #152 - players couldn't see their combat task status or when attacks would execute

**Changes:**
- Added `CombatTaskStatusBar` component that shows task status + countdown
- Integrated into `CombatTargets` - shows up right above the target list when in combat
- Progress bar counts down (orange bar shrinks as time passes)
- Status badges for PENDING/EXECUTING/ERROR/READY states
- Wired up `rawEndBlock` from polling data instead of passing currentBlock as prop

**Key files:**
- `src/components/game/controls/CombatTaskStatusBar.tsx` - new component
- `src/components/game/controls/CombatTargets.tsx` - integration point
- Prop threading through `GameView` -> `CombatTargets` chain

**Behavior:**
- Bar stays visible during combat (uses `isInCombat` flag to prevent flickering)
- When no active task but still in combat, shows "READY" state
- Error state shows "Attack to restart combat" instead of generic error message
- Styled to match the target button sizing/colors

**Testing:**
- Tested with actual combat tasks - countdown works correctly
- Error states display the helpful message
- Bar doesn't flicker when task data updates during combat

The progress calculation assumes ~5 block task duration for the visual scaling - might need tweaking based on actual task timings.