### PR TITLE
Add "Get More ShMON" Link

### DIFF
--- a/src/components/WalletBalances.tsx
+++ b/src/components/WalletBalances.tsx
@@ -10,6 +10,7 @@ import {
   LOW_SESSION_KEY_THRESHOLD,
   MIN_SAFE_OWNER_BALANCE,
 } from "@/config/wallet";
+import { SHMONAD_WEBSITE_URL } from "@/config/env";
 import { TOPUP_MULTIPLIER } from '@/config/shmon';
 import { BalanceDisplay } from './wallet/BalanceDisplay';
 import { DirectFundingCard } from './wallet/DirectFundingCard';
@@ -170,6 +171,10 @@ const WalletBalances: React.FC = () => {
           label="Liquid"
           balance={unbondedBalance}
           tokenType="shMON"
+          actionLink={{
+            label: "(Get More ShMON)",
+            url: SHMONAD_WEBSITE_URL
+          }}
         />
         <BalanceDisplay
           label="Owner Wallet"

--- a/src/components/WalletBalances.tsx
+++ b/src/components/WalletBalances.tsx
@@ -172,7 +172,7 @@ const WalletBalances: React.FC = () => {
           balance={unbondedBalance}
           tokenType="shMON"
           actionLink={{
-            label: "(Get More ShMON)",
+            label: "Get More ShMON",
             url: SHMONAD_WEBSITE_URL
           }}
         />

--- a/src/components/wallet/BalanceDisplay.tsx
+++ b/src/components/wallet/BalanceDisplay.tsx
@@ -29,18 +29,13 @@ export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
         <Badge colorScheme={badgeColor} size="xs">
           {tokenType}
         </Badge>
-      </Flex>
-      <div className="flex items-center gap-2">
-        <div className="font-semibold text-amber-300 text-sm">
-          {formattedBalance}
-        </div>
         {actionLink && (
           <Box
             as="a"
             href={actionLink.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-amber-900/30 border border-amber-700/50 hover:bg-amber-900/50 hover:border-amber-600 transition-all duration-200 group"
+            className="inline-flex items-center gap-1 px-2 py-0.5 ml-2 rounded-md bg-amber-900/30 border border-amber-700/50 hover:bg-amber-900/50 hover:border-amber-600 transition-all duration-200 group"
             _hover={{ transform: "translateY(-1px)" }}
           >
             <span className="text-xs font-medium text-amber-300 group-hover:text-amber-200">
@@ -57,6 +52,9 @@ export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
             </svg>
           </Box>
         )}
+      </Flex>
+      <div className="font-semibold text-amber-300 text-sm">
+        {formattedBalance}
       </div>
     </div>
   );

--- a/src/components/wallet/BalanceDisplay.tsx
+++ b/src/components/wallet/BalanceDisplay.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Badge } from "@chakra-ui/react";
+import { Flex, Badge, Box } from "@chakra-ui/react";
 
 interface BalanceDisplayProps {
   label: string;
@@ -35,14 +35,27 @@ export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
           {formattedBalance}
         </div>
         {actionLink && (
-          <a
+          <Box
+            as="a"
             href={actionLink.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs gold-text-light hover:text-amber-300 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-amber-900/30 border border-amber-700/50 hover:bg-amber-900/50 hover:border-amber-600 transition-all duration-200 group"
+            _hover={{ transform: "translateY(-1px)" }}
           >
-            {actionLink.label}
-          </a>
+            <span className="text-xs font-medium text-amber-300 group-hover:text-amber-200">
+              Get More
+            </span>
+            <svg
+              className="w-3 h-3 text-amber-400 group-hover:text-amber-300"
+              fill="none"
+              strokeWidth="2"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+            </svg>
+          </Box>
         )}
       </div>
     </div>

--- a/src/components/wallet/BalanceDisplay.tsx
+++ b/src/components/wallet/BalanceDisplay.tsx
@@ -6,6 +6,10 @@ interface BalanceDisplayProps {
   balance: string;
   tokenType: "MON" | "shMON";
   precision?: number;
+  actionLink?: {
+    label: string;
+    url: string;
+  };
 }
 
 export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
@@ -13,6 +17,7 @@ export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
   balance,
   tokenType,
   precision = 4,
+  actionLink,
 }) => {
   const badgeColor = tokenType === "MON" ? "purple" : "yellow";
   const formattedBalance = parseFloat(balance).toFixed(precision);
@@ -25,8 +30,20 @@ export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({
           {tokenType}
         </Badge>
       </Flex>
-      <div className="font-semibold text-amber-300 text-sm">
-        {formattedBalance}
+      <div className="flex items-center gap-2">
+        <div className="font-semibold text-amber-300 text-sm">
+          {formattedBalance}
+        </div>
+        {actionLink && (
+          <a
+            href={actionLink.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs gold-text-light hover:text-amber-300 hover:underline transition-colors"
+          >
+            {actionLink.label}
+          </a>
+        )}
       </div>
     </div>
   );

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -49,4 +49,7 @@ export const ENABLE_WEBSOCKET =
 export const MAX_PLAYER_LEVEL = 100;
 export const MAX_SESSION_KEY_VALIDITY_BLOCKS = 172800; // About 24 hours at 0.5s blocks (24*60*60 / 0.5)
 
+// External URLs
+export const SHMONAD_WEBSITE_URL = "https://shmonad.xyz/";
+
 // Gas limits for different actions (adjust based on network and contract complexity)


### PR DESCRIPTION
## Summary

<img width="360" alt="image" src="https://github.com/user-attachments/assets/99c00c60-e5d2-4314-87ad-30b2d3a544b1" />


- Add a "Get More" button next to the Liquid ShMON balance
- Button opens https://shmonad.xyz/ in a new tab
- Styled with game-appropriate amber/gold colors and hover effects

## Changes
1. Added  constant to config
2. Updated  component to support optional action links
3. Added "Get More" button with arrow icon for Liquid ShMON balance

## Visual Design
- Button-like appearance with amber background and border
- Arrow icon indicates external link
- Hover effects: background brightens, slight lift animation
- Positioned after the ShMON badge for logical flow
- All balance numbers remain right-aligned

## Testing
- [x] Link opens https://shmonad.xyz/ in new tab
- [x] Hover effects work properly
- [x] Balance numbers stay aligned
- [x] Other balance displays unchanged
- [x] Security attributes included (rel="noopener noreferrer")

Closes #167

🤖 Generated with [Claude Code](https://claude.ai/code)