### PR TITLE
Fix enemy attack messages in combat log

### DIFF
--- a/src/utils/__tests__/log-builder.test.ts
+++ b/src/utils/__tests__/log-builder.test.ts
@@ -175,6 +175,45 @@ describe('log-builder', () => {
       expect(result1.text).toMatch(/sloshes acidic goo at|oozes toward|splashes/);
     });
 
+    it('should handle Elite monster attacks with correct verbs', () => {
+      const eliteSnailCharacter = {
+        class: CharacterClass.Elite,
+        index: 5, // Location index
+        level: 10,
+        name: 'Elite Venomous Snail',
+      };
+
+      const rawLog: LogEntryRaw = {
+        logIndex: 150,
+        blocknumber: 1000n,
+        timestamp: Date.now(),
+        type: LogType.Combat,
+        attacker: {
+          id: 'elite-snail-1',
+          name: 'Elite Venomous Snail',
+          index: 5,
+        },
+        defender: mockPlayer,
+        areaId: 5n,
+        isPlayerInitiated: false,
+        details: {
+          hit: true,
+          damageDone: 50,
+        },
+        displayMessage: 'raw message',
+        actor: eliteSnailCharacter,
+        target: mockPlayerCharacter,
+      };
+
+      const result = enrichLog(rawLog, 1, undefined, undefined, 'John');
+
+      expect(result.text).toContain('Elite Venomous Snail');
+      expect(result.text).toContain('you');
+      expect(result.text).toContain('for 50 damage');
+      // Should use Venomous Snail's attack verbs (id 5), not generic "strikes"
+      expect(result.text).toMatch(/leaves a slimy trail toward|slowly approaches|secretes poison at/);
+    });
+
     it('should not include weapon text for monster attacks', () => {
       const beastCharacter = {
         class: CharacterClass.Basic,

--- a/src/utils/__tests__/log-helpers.test.ts
+++ b/src/utils/__tests__/log-helpers.test.ts
@@ -2,6 +2,7 @@ import {
   formatActorName,
   getPlayerTitle,
   pickAttackVerb,
+  getMonsterTypeFromName,
   getSignatureAbility,
   getWeaponName,
   getArmorName,
@@ -183,7 +184,71 @@ describe('log-helpers', () => {
     });
   });
 
+  describe('getMonsterTypeFromName', () => {
+    it('should return correct type for basic monster names', () => {
+      expect(getMonsterTypeFromName('Dungeon Crab')).toBe(3);
+      expect(getMonsterTypeFromName('Cave Viper')).toBe(7);
+      expect(getMonsterTypeFromName('Goblin Scout')).toBe(9);
+    });
+    
+    it('should handle Elite prefix', () => {
+      expect(getMonsterTypeFromName('Elite Dungeon Crab')).toBe(3);
+      expect(getMonsterTypeFromName('Elite Cave Viper')).toBe(7);
+    });
+    
+    it('should handle Boss suffix', () => {
+      expect(getMonsterTypeFromName('Dungeon Crab Boss')).toBe(3);
+      expect(getMonsterTypeFromName('Cave Viper Boss')).toBe(7);
+    });
+    
+    it('should handle special boss prefixes', () => {
+      expect(getMonsterTypeFromName('Dread Dungeon Crab Boss')).toBe(3);
+      expect(getMonsterTypeFromName('Nightmare Cave Viper Boss')).toBe(7);
+      expect(getMonsterTypeFromName('Infernal Goblin Scout Boss')).toBe(9);
+    });
+    
+    it('should return null for named bosses', () => {
+      expect(getMonsterTypeFromName('Molandak')).toBeNull();
+      expect(getMonsterTypeFromName('Salmonad')).toBeNull();
+    });
+    
+    it('should return null for special cases', () => {
+      expect(getMonsterTypeFromName('Dungeon Floor Boss')).toBeNull();
+      expect(getMonsterTypeFromName('Keone')).toBeNull();
+    });
+    
+    it('should return null for unknown names', () => {
+      expect(getMonsterTypeFromName('Unknown Monster')).toBeNull();
+    });
+  });
+
   describe('pickAttackVerb', () => {
+    it('should accept monster name and return correct verbs', () => {
+      const verb1 = pickAttackVerb('Dungeon Crab', 0);
+      expect(['pinches with claws', 'scuttles toward', 'snaps at']).toContain(verb1);
+      
+      const verb2 = pickAttackVerb('Cave Viper', 0);
+      expect(['strikes with venomous fangs', 'coils around', 'hisses at']).toContain(verb2);
+      
+      const verb3 = pickAttackVerb('Goblin Scout', 0);
+      expect(['scouts and strikes', 'darts toward', 'slashes with dagger']).toContain(verb3);
+    });
+    
+    it('should handle Elite monsters', () => {
+      const verb = pickAttackVerb('Elite Dungeon Crab', 0);
+      expect(['pinches with claws', 'scuttles toward', 'snaps at']).toContain(verb);
+    });
+    
+    it('should return default for unknown monsters', () => {
+      const verb = pickAttackVerb('Unknown Monster', 0);
+      expect(verb).toBe('attacks');
+    });
+    
+    it('should still accept numeric index for backward compatibility', () => {
+      const verb = pickAttackVerb(1, 0);
+      expect(['sloshes acidic goo at', 'oozes toward', 'splashes']).toContain(verb);
+    });
+    
     it('should return deterministic verbs based on logIndex', () => {
       const verb1 = pickAttackVerb(1, 100); // Slime
       const verb2 = pickAttackVerb(1, 100); // Same inputs

--- a/src/utils/log-builder.ts
+++ b/src/utils/log-builder.ts
@@ -110,14 +110,18 @@ export function enrichLog(raw: LogEntryRaw, playerIndex?: number | null, playerW
       // Check if this is likely a monster
       // First check class, then check if the name matches a known monster name
       const actorNameLower = actor.name?.toLowerCase() || '';
+      // Strip "Elite " prefix for checking
+      const nameWithoutElite = actorNameLower.startsWith('elite ') 
+        ? actorNameLower.substring(6) 
+        : actorNameLower;
       const isNamedLikeMonster = Object.values(MONSTER_NAMES).some(monsterName => 
-        monsterName.toLowerCase() === actorNameLower
+        monsterName.toLowerCase() === nameWithoutElite
       );
       const isLikelyMonster = isMonster(actor) || isNamedLikeMonster;
       
       let verb = "hits";
       if (isLikelyMonster) {
-        verb = pickAttackVerb(actor.index, Number(raw.areaId));
+        verb = pickAttackVerb(actor.name, Number(raw.areaId));
       } else {
         // Use correct grammar: "You strike" vs "John strikes"
         if (isActorPlayer) {


### PR DESCRIPTION
## Summary
- Fixed incorrect attack messages for monsters in the combat log
- Added support for Elite monster attack messages
- Improved monster type detection to handle prefixes correctly

## Problem
The combat log was showing incorrect attack messages for monsters. For example:
- "Dungeon Crab darts toward you" - using Goblin Scout's attack instead of Dungeon Crab's
- "Cave Viper soars and strikes with talons" - using Griffin's attack instead of Cave Viper's
- "Elite Venomous Snail strikes you" - using generic "strikes" instead of snail-specific attacks

## Root Cause
The code was using the character's location `index` instead of determining the monster type from the monster's name. The contract generates monster names dynamically, so we needed to map from names back to monster type IDs.

## Solution
1. Created `getMonsterTypeFromName` function to map monster names to their type IDs (1-64)
2. Updated `pickAttackVerb` to accept monster names and use the correct type ID
3. Fixed Elite monster detection by stripping the "Elite " prefix before checking
4. Added comprehensive tests for all scenarios

## Test Plan
- [x] Run `npm test` - all tests pass
- [x] Run `npm run build` - builds successfully
- [x] Added new tests for Elite monsters and name-based attack verb selection
- [ ] Test in-game that Dungeon Crab shows "scuttles toward" instead of "darts toward"
- [ ] Test that Elite monsters show correct attack verbs
- [ ] Test that boss monsters with special prefixes work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)