### PR TITLE
Fix: Prioritize no character check over session key validation

### DIFF
--- a/src/hooks/useAppInitializerMachine.ts
+++ b/src/hooks/useAppInitializerMachine.ts
@@ -31,12 +31,18 @@ export function useAppInitializerMachine(isCheckingContract = false): AuthStateC
 
   // Handle wallet initialization
   useEffect(() => {
-    if (state.value === 'initializing' && 
-        walletInitialized && 
-        game.isInitialized && 
-        embeddedWallet?.address && 
-        injectedWallet?.address) {
-      send({ type: 'WALLET_INITIALIZED', hasEmbeddedWallet: true });
+    if (state.value === 'initializing') {
+      // If wallet is initialized but we have no wallets, transition to noWallet state
+      if (walletInitialized && game.isInitialized && !injectedWallet?.address) {
+        send({ type: 'WALLET_INITIALIZED', hasEmbeddedWallet: false });
+      }
+      // If we have both wallets, proceed to load game data
+      else if (walletInitialized && 
+               game.isInitialized && 
+               embeddedWallet?.address && 
+               injectedWallet?.address) {
+        send({ type: 'WALLET_INITIALIZED', hasEmbeddedWallet: true });
+      }
     }
   }, [walletInitialized, game.isInitialized, state.value, embeddedWallet?.address, injectedWallet?.address, send]);
   

--- a/src/machines/appInitializerMachine.ts
+++ b/src/machines/appInitializerMachine.ts
@@ -86,21 +86,13 @@ export const appInitializerMachine = createMachine({
     
     loadingGameData: {
       on: {
-        GAME_DATA_LOADED: [
-          {
-            target: 'noCharacter',
-            guard: ({ context, event }) => 
-              event.characterId === '0x0000000000000000000000000000000000000000000000000000000000000000' &&
-              context.hasSeenWelcome === true,
-          },
-          {
-            target: 'checkingCharacterStatus',
-            actions: assign(({ event }) => ({
-              characterId: event.characterId,
-              sessionKeyState: event.sessionKeyState || undefined,
-            })),
-          },
-        ],
+        GAME_DATA_LOADED: {
+          target: 'checkingCharacterStatus',
+          actions: assign(({ event }) => ({
+            characterId: event.characterId,
+            sessionKeyState: event.sessionKeyState || undefined,
+          })),
+        },
         GAME_DATA_ERROR: {
           target: 'error',
           actions: assign(({ event }) => ({
@@ -162,6 +154,12 @@ export const appInitializerMachine = createMachine({
         CHARACTER_DIED: 'characterDead',
       },
       always: [
+        {
+          target: 'noCharacter',
+          guard: ({ context }) => 
+            !context.characterId || 
+            context.characterId === '0x0000000000000000000000000000000000000000000000000000000000000000',
+        },
         {
           target: 'checkingSessionKey',
         },


### PR DESCRIPTION
## Summary
This PR fixes a bug where users without a character could get stuck on session key prompts instead of being redirected to the character creation page.

### The Issue
When a user has no character, they should be redirected to `/create` page immediately, regardless of their session key status. Previously, the state machine would check session keys before checking if the user had a character, which could leave users stuck.

### The Fix
- Modified the `checkingCharacterStatus` state to check for no character first before proceeding to session key validation
- Removed the early no-character check from `loadingGameData` state (it's now handled consistently in one place)
- This ensures users are always redirected to create a character when they don't have one

## Test plan
- [x] All existing tests pass
- [x] When a user has no character, they are redirected to `/create` regardless of session key status
- [x] Session key validation still works correctly when user has a character
- [x] Character creation flow works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>