### PR TITLE
Fix welcome screen priority over character creation

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -4,17 +4,21 @@ import { useSimplifiedGameState } from '../hooks/game/useSimplifiedGameState';
 import { useAuthState } from '@/contexts/AuthStateContext';
 import { AuthState } from '@/types/auth';
 import { AppInitializerStateRenderer, stateToComponentMap } from './AppInitializerStateRenderer';
+import { useWelcomeScreen } from './onboarding/WelcomeScreen';
+import { useWallet } from '@/providers/WalletProvider';
 
 const AppInitializer: React.FC = () => {
   const authState = useAuthState();
   const game = useSimplifiedGameState();
   const router = useRouter();
   const pathname = usePathname();
+  const { currentWallet } = useWallet();
+  const { hasSeenWelcome } = useWelcomeScreen(currentWallet !== 'none' ? currentWallet : undefined);
 
   // Effect for redirection based on auth state and pathname
   useEffect(() => {
-    // Redirect to character creation when in NO_CHARACTER state
-    if (authState.state === AuthState.NO_CHARACTER && pathname !== '/create') {
+    // Only redirect to character creation if welcome screen has been seen
+    if (authState.state === AuthState.NO_CHARACTER && pathname !== '/create' && hasSeenWelcome) {
       router.push('/create');
     }
     
@@ -22,7 +26,7 @@ const AppInitializer: React.FC = () => {
     if (authState.state === AuthState.READY && pathname === '/create') {
       router.push('/');
     }
-  }, [authState.state, pathname, router]);
+  }, [authState.state, pathname, router, hasSeenWelcome]);
 
   // Render content based on current auth state using the declarative mapping
   const renderContent = (state: AuthState): React.ReactNode => {


### PR DESCRIPTION
## Summary
- Fixed issue where new users were being redirected to character creation before seeing the welcome screen
- Welcome screen now properly takes priority over character creation redirect
- Added `hasSeenWelcome` check to prevent premature redirects

## Changes
- Modified `AppInitializer.tsx` to check if welcome screen has been seen before redirecting to `/create`
- Imported and integrated `useWelcomeScreen` hook to track onboarding status

## Test Plan
1. Clear localStorage to simulate a new user
2. Connect wallet for the first time
3. Verify welcome screen appears before any redirect to character creation
4. Complete or skip welcome screen
5. Verify redirect to `/create` happens only after welcome screen is dismissed
6. Refresh page and verify no welcome screen appears (already seen)

🤖 Generated with [Claude Code](https://claude.ai/code)