### PR TITLE
Fix ApplyPoison ability's 13-stage structure handling

### DIFF
--- a/src/components/game/controls/AbilityButton.tsx
+++ b/src/components/game/controls/AbilityButton.tsx
@@ -56,7 +56,7 @@ const ABILITY_COOLDOWN_DURATIONS: { [key in domain.Ability]?: number } = {
   [domain.Ability.ShieldBash]: 12,       // 24 blocks * 0.5s
   [domain.Ability.ShieldWall]: 12,       // 24 blocks * 0.5s
   [domain.Ability.EvasiveManeuvers]: 9,  // 18 blocks * 0.5s
-  [domain.Ability.ApplyPoison]: 32,      // 64 blocks * 0.5s
+  [domain.Ability.ApplyPoison]: 30.5,    // 61 blocks * 0.5s (5 windup + 40 poison + 16 cooldown)
   [domain.Ability.Pray]: 36,             // 72 blocks * 0.5s
   [domain.Ability.Smite]: 12,            // 24 blocks * 0.5s
   [domain.Ability.Fireball]: 28,         // 56 blocks * 0.5s

--- a/src/data/abilities.ts
+++ b/src/data/abilities.ts
@@ -45,7 +45,7 @@ export const ABILITY_METADATA: Record<Ability, AbilityMetadata> = {
   },
   [Ability.ApplyPoison]: {
     name: 'Apply Poison',
-    description: 'Hurl a vial of deadly poison at the target, causing damage over time.',
+    description: 'Hurl a vial of deadly poison at the target, dealing damage over 10 rounds (2% health + 1 per round).',
     requiresTarget: true,
   },
 

--- a/src/hooks/game/useAbilityCooldowns.ts
+++ b/src/hooks/game/useAbilityCooldowns.ts
@@ -16,7 +16,7 @@ const ABILITY_COOLDOWN_BLOCKS: Record<domain.Ability, number> = {
     [domain.Ability.ShieldBash]: 6,
     [domain.Ability.ShieldWall]: 42,
     [domain.Ability.EvasiveManeuvers]: 40, 
-    [domain.Ability.ApplyPoison]: 61,
+    [domain.Ability.ApplyPoison]: 61, // Total: 5 (windup) + 40 (poison rounds) + 16 (cooldown) = 61 blocks
     [domain.Ability.Pray]: 49,
     [domain.Ability.Smite]: 26,
     [domain.Ability.Fireball]: 23,

--- a/src/hooks/game/useAbilityTracker.ts
+++ b/src/hooks/game/useAbilityTracker.ts
@@ -12,7 +12,7 @@ const ABILITY_STAGE_DURATIONS: Record<domain.Ability, { charging: number; action
   [domain.Ability.ShieldWall]: { charging: 3, action: 3, cooldown: 24 },
   // Rogue abilities  
   [domain.Ability.EvasiveManeuvers]: { charging: 2, action: 2, cooldown: 18 },
-  [domain.Ability.ApplyPoison]: { charging: 6, action: 4, cooldown: 64 },
+  [domain.Ability.ApplyPoison]: { charging: 5, action: 40, cooldown: 16 }, // Stage 1: 5 blocks, Stages 2-11: 40 blocks total, Stage 12: 16 blocks
   // Monk abilities
   [domain.Ability.Pray]: { charging: 8, action: 4, cooldown: 72 },
   [domain.Ability.Smite]: { charging: 3, action: 1, cooldown: 24 },

--- a/src/utils/__tests__/ability-enhancements.test.ts
+++ b/src/utils/__tests__/ability-enhancements.test.ts
@@ -55,9 +55,9 @@ describe('ability-enhancements', () => {
     it('should handle Apply Poison with stage information', () => {
       const result = calculateAbilityEnhancement(Ability.ApplyPoison, mockCharacter, 25, 3);
 
-      expect(result.description).toBe('poison damage (Stage 3/6, Level 15)');
+      expect(result.description).toBe('poison damage (Round 2/10, Level 15)');
       expect(result.stage).toBe(3);
-      expect(result.totalStages).toBe(6);
+      expect(result.totalStages).toBe(13);
     });
 
     it('should handle buff abilities', () => {

--- a/src/utils/__tests__/log-builder.test.ts
+++ b/src/utils/__tests__/log-builder.test.ts
@@ -691,7 +691,7 @@ describe('log-builder', () => {
         details: {
           damageDone: 15,
           lootedWeaponID: 6, // Apply Poison ability ID (from Ability enum)
-          lootedArmorID: 3,  // Stage 3 of 6 (poison damage stages)
+          lootedArmorID: 3,  // Stage 3 of 13 (poison round 2 of 10)
           hit: true,
         },
         displayMessage: 'raw message',
@@ -712,7 +712,7 @@ describe('log-builder', () => {
       const result = enrichLog(rawLog, 1, undefined, undefined, 'TestPlayer');
 
       expect(result.text).toContain('uses Ability **Apply Poison** against');
-      expect(result.text).toContain('poison damage (Stage 3/6, Level 20)');
+      expect(result.text).toContain('poison damage (Round 2/10, Level 20)');
     });
 
     it('should handle self-targeted abilities correctly', () => {

--- a/src/utils/ability-enhancements.ts
+++ b/src/utils/ability-enhancements.ts
@@ -87,15 +87,64 @@ export function calculateAbilityEnhancement(
     
     case Ability.ApplyPoison: {
       // Multi-stage ability with damage over time
-      const totalStages = 6; // Damage stages before cooldown
+      // Stage 1: Windup (5 blocks)
+      // Stages 2-11: Apply poison damage for 10 rounds (4 blocks each)
+      // Stage 12: Cooldown period (16 blocks)
+      // Stage 13: Resets to stage 0
       
+      if (stage === 1) {
+        // Windup stage
+        return {
+          baseValue: 0,
+          enhancedValue: 0,
+          bonus: 0,
+          description: `preparing poison attack (Level ${level})`,
+          stage: 1,
+          totalStages: 13,
+        };
+      } else if (stage && stage >= 2 && stage <= 11) {
+        // Poison damage rounds (2-11)
+        const poisonRound = stage - 1; // Round 1-10
+        const isFirstRound = stage === 2;
+        const isLastRound = stage === 11;
+        
+        let description = '';
+        if (isFirstRound) {
+          description = `applying poison (Round ${poisonRound}/10, Level ${level})`;
+        } else if (isLastRound) {
+          description = `final poison damage and removing effect (Round ${poisonRound}/10, Level ${level})`;
+        } else {
+          description = `poison damage (Round ${poisonRound}/10, Level ${level})`;
+        }
+        
+        return {
+          baseValue: rawValue,
+          enhancedValue: rawValue,
+          bonus: 0,
+          description,
+          stage,
+          totalStages: 13,
+        };
+      } else if (stage === 12) {
+        // Cooldown stage
+        return {
+          baseValue: 0,
+          enhancedValue: 0,
+          bonus: 0,
+          description: `recovering from poison ability (Level ${level})`,
+          stage: 12,
+          totalStages: 13,
+        };
+      }
+      
+      // Default/unknown stage
       return {
         baseValue: rawValue,
         enhancedValue: rawValue,
         bonus: 0,
-        description: `poison damage (Stage ${stage || 1}/${totalStages}, Level ${level})`,
-        stage: stage || 1,
-        totalStages,
+        description: `poison effect (Level ${level})`,
+        stage: stage || 0,
+        totalStages: 13,
       };
     }
     


### PR DESCRIPTION
## Summary
- Fixed ApplyPoison ability to correctly handle its 13-stage structure (previously only showed 6 stages)
- Updated combat log messages to show poison rounds 1-10 with clear messaging
- Corrected ability cooldown calculations and UI display

## Test plan
### Manual Testing
- [ ] Use a Rogue character and activate ApplyPoison ability on a target
- [ ] Verify combat logs show:
  - "preparing poison attack" during windup (stage 1)
  - "applying poison (Round 1/10)" on first damage application (stage 2)
  - "poison damage (Round X/10)" for rounds 2-9 (stages 3-10)
  - "final poison damage and removing effect (Round 10/10)" on last round (stage 11)
  - "recovering from poison ability" during cooldown (stage 12)
- [ ] Verify ability button shows correct total cooldown time (30.5 seconds)
- [ ] Verify ability tracker shows correct stage durations

### Automated Testing
- [x] All unit tests pass
- [x] Build completes successfully
- [x] No TypeScript errors

### Existing Functionality
- [ ] Other abilities (ShieldBash, Fireball, etc.) still work correctly
- [ ] Ability cooldowns and UI updates function as before
- [ ] Combat log formatting remains consistent for non-poison abilities

Fixes #206

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>